### PR TITLE
feat: broaden typedefs for path to include arrays and regex

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,7 +27,7 @@ export interface ExpressRegex extends RegExp {
 }
 
 export interface RouteMetaData {
-  path: string;
+  path: string | string[] | ExpressRegex;
   pathParams: Parameter[];
   method: string;
   metadata?: any;


### PR DESCRIPTION
The Router library used by Express allows for a number of different path specifications:
 - `string`
 - `string[]`
 - `regex`

Just updating the typedefs to match.  See:
 - https://github.com/pillarjs/router/blob/19f241bca8789a684d694e95711ddd1e6b83d8a4/lib/layer.js#L50
 - https://github.com/pillarjs/router/blob/19f241bca8789a684d694e95711ddd1e6b83d8a4/lib/layer.js#L93