### PR TITLE
tooling: release script + devtools modernization design

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,38 +22,140 @@ access section).
 
 After this is configured, the legacy npm automation token (if any) can be revoked.
 
-## Cutting a Release
+## Cutting a Release (Recommended: One-Command Script)
+
+```bash
+./scripts/release.sh patch    # 1.0.6 -> 1.0.7
+./scripts/release.sh minor    # 1.0.6 -> 1.1.0
+./scripts/release.sh major    # 1.0.6 -> 2.0.0
+```
+
+The script handles the full flow end-to-end:
+
+1. Validates preconditions (clean working tree, on `main` and up to date,
+   `gh` authenticated, no in-flight release PR).
+2. Computes the new version, creates branch `release/X.Y.Z`.
+3. Updates `CHANGELOG.md`'s `[Unreleased]` section to a dated `[X.Y.Z]` block
+   (or fills in a pre-seeded `[X.Y.Z]` section's date if present).
+4. Bumps version in `package.json` and `package-lock.json`.
+5. Commits and pushes the branch; opens a PR via `gh pr create`.
+6. Waits for the PR's CI checks to pass.
+7. Pauses for the maintainer to merge the PR (or enables GitHub auto-merge
+   with `--auto-merge`).
+8. After merge: fetches `main`, **tags the merge commit** (not the bump commit
+   inside the branch — see "Tag placement" below), pushes the tag.
+9. Watches the `Release` workflow run, then verifies the new version lands on
+   npm with the provenance badge.
+
+Run `./scripts/release.sh --help` for flags.
+
+## Cutting a Release (Manual Procedure)
+
+The script is the canonical path; this manual procedure documents what it does
+and serves as a fallback if the script is unavailable.
+
+`main` is a protected branch — direct pushes are rejected. All releases go
+through a PR.
 
 1. Ensure `main` is green in CI and contains everything intended for the release.
-2. Move the `[Unreleased]` section of `CHANGELOG.md` under a new `[X.Y.Z]` heading
-   with today's date. Add an `[Unreleased]` placeholder back at the top. Update
-   the compare-link footnotes.
-3. Commit the CHANGELOG change.
-4. Run `npm version <patch|minor|major>`. This:
-   - lints (`preversion`)
-   - bumps the version in `package.json` and `package-lock.json`
-   - formats and stages source (`version`)
-   - commits and creates an annotated `v<x.y.z>` tag
-   - pushes commit + tag to origin (`postversion`, `git push --follow-tags`)
-5. The `Release` workflow fires on the tag, runs tests/lint/build, publishes to
-   npm with provenance, and creates a GitHub Release.
-6. Verify on https://www.npmjs.com/package/express-route-parser that the new
-   version shows a "Provenance" badge.
+2. Decide the new version (`X.Y.Z`).
+3. Create a branch from `main`:
+   ```bash
+   git switch main && git pull --ff-only
+   git switch -c release/X.Y.Z
+   ```
+4. Update `CHANGELOG.md`:
+   - If you were appending changes to `[Unreleased]`, move that section under a
+     new `[X.Y.Z]` heading with today's date.
+   - If `[X.Y.Z]` is already pre-seeded with planned content (as was the case
+     for 1.0.6), just fill in the date placeholder.
+   - Add an `[Unreleased]` placeholder back at the top.
+   - Update the compare-link footnotes.
+5. Bump the version in **both** `package.json` and `package-lock.json` (lockfile
+   contains the version in two places: top-level `version` and `packages."".version`).
+6. Commit and push:
+   ```bash
+   git add CHANGELOG.md package.json package-lock.json
+   git commit -m "X.Y.Z"      # match prior tag-commit convention
+   git push -u origin release/X.Y.Z
+   ```
+7. Open a PR:
+   ```bash
+   gh pr create --title "Release X.Y.Z" --body "..."
+   ```
+8. Wait for CI to pass, then merge the PR (squash, merge-commit, or rebase — all work).
+9. **Tag the merge commit on `main`** — see "Tag placement" below for why this
+   matters:
+   ```bash
+   git switch main && git pull --ff-only
+   git tag -a vX.Y.Z -m "X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+10. The `Release` workflow fires on the tag push. It runs tests/lint/build,
+    publishes to npm with provenance, and creates a GitHub Release with
+    auto-generated notes.
+11. Verify on https://www.npmjs.com/package/express-route-parser that the new
+    version shows a "Provenance" badge.
+
+## Tag Placement (Important)
+
+**Always tag the merge commit on `main`, not the version-bump commit inside the
+release branch.**
+
+GitHub's auto-generated release notes (used by `softprops/action-gh-release`
+with `generate_release_notes: true`) discover PRs merged between the previous
+release tag and the current tag by walking the commit graph. If the tag points
+at a commit that's *inside* the release branch (e.g., the bump commit), then
+the release PR's merge commit is unreachable from the tag, and any PRs that
+merged via that PR's flow won't appear in the notes.
+
+This was learned the hard way during the `1.0.6` ship — the tag was placed on
+the bump commit, the auto-generated notes only mentioned the previous PR (#8),
+and the notes had to be manually overwritten. The `release.sh` script and the
+manual procedure above both place the tag on the merge commit to avoid this.
+
+Symptom that you got it wrong: the GitHub Release notes show fewer PRs than
+you expected for the version. Fix: edit the release notes manually, and place
+future tags correctly.
 
 ## Rollback
 
 If a bad version is published:
 
-- Within 72 hours: `npm unpublish express-route-parser@<bad-version>` (locally,
-  using a personal token — OIDC does not cover unpublish).
-- After 72 hours: publish a `<bad-version>+1` patch with the fix; users can be
-  steered via `npm deprecate`.
+- **Within 72 hours**: `npm unpublish express-route-parser@<bad-version>`
+  (locally, using a personal token — OIDC does not cover unpublish, so a
+  classic auth token is needed for this).
+- **After 72 hours**: publish a `<bad-version>+1` patch with the fix; users
+  can be steered via `npm deprecate`.
 
-## Manual Re-Run
+In both cases, also update `CHANGELOG.md` and consider editing the GitHub
+Release to note the issue.
 
-If the publish workflow fails for a transient reason (registry blip, etc.) and
-the tag is already pushed, re-run via:
+## Manual Re-Run of the Publish Workflow
+
+If the publish workflow fails for a transient reason (registry blip, GitHub
+Actions infra issue) and the tag is already pushed, re-run via:
 
 - GitHub UI: Actions → Release → Run workflow → enter the tag (e.g. `v1.0.6`).
-- This uses the `workflow_dispatch` trigger and produces the same result as a
+- The workflow uses `workflow_dispatch` and produces the same result as a
   tag push.
+
+## Releasing With No Source Changes
+
+Sometimes you'll want to release just to update metadata (engines, scripts,
+docs, devDeps) — i.e., the published `lib/` is unchanged from the previous
+version.
+
+In that case: still cut a release if any consumer-visible field changed
+(`engines.node`, `peerDependencies`, package types). If only `devDependencies`
+or CI changed, **don't release** — the lib/ output is byte-identical and there
+is nothing for consumers to install.
+
+A "did anything publishable change?" sanity check:
+
+```bash
+git diff v<prev>..HEAD -- lib/ package.json
+```
+
+If both are unchanged or only `version` differs in `package.json`, a release
+adds zero value.

--- a/docs/design/devtools-modernization.md
+++ b/docs/design/devtools-modernization.md
@@ -1,0 +1,647 @@
+# Design: Devtools Modernization
+
+## Overview
+
+This design replaces the project's stale dev tooling with current 2026 stable
+releases. **Zero published-API surface changes are intended** — the `lib/`
+output should be byte-equivalent to `1.0.6` (modulo any TypeScript 6 declaration
+ordering churn, which is monitored as part of acceptance).
+
+Scope:
+
+- Jest 28 + ts-jest → **Vitest 4**
+- TypeScript 4.7 → **TypeScript 6.0**
+- ESLint 8 (.eslintrc.js) → **ESLint 10 (flat config)**
+- Prettier 2 → **Prettier 3**
+- Add **`expectTypeOf` type tests** to pin the public API's type shape
+- Drop dead deps (`eslint-plugin-react`, `tslint-config-prettier`,
+  `eslint-plugin-prefer-arrow`)
+
+Out of scope (already shipped in `1.0.6`):
+
+- CI matrix update (Node 20/22/24) — done in `.github/workflows/ci.yml`
+- `engines.node` field — present, currently `>=18`. **Bumping to `>=20` is
+  proposed in this design** because Vitest 4 and ESLint 10 require Node 20+
+  for development. See Q1 below.
+
+## Verified Facts (2026-05-03, queried directly from npm registry)
+
+Do not substitute training-memory values for these; the major-version landscape
+is current as of design time.
+
+| Package                              | Latest stable | Node engines                            |
+| ------------------------------------ | ------------- | --------------------------------------- |
+| `typescript`                         | **6.0.3**     | `>=14.17`                               |
+| `vitest`                             | **4.1.5**     | `^20.0.0 \|\| ^22.0.0 \|\| >=24.0.0`    |
+| `@vitest/coverage-v8`                | **4.1.5**     | (matches `vitest`)                      |
+| `eslint`                             | **10.3.0**    | `^20.19.0 \|\| ^22.13.0 \|\| >=24`      |
+| `typescript-eslint` (unified pkg)    | **8.59.1**    | (typescript-eslint v8 line)             |
+| `prettier`                           | **3.8.3**     | `>=14`                                  |
+| `eslint-plugin-jsdoc`                | **62.9.0**    | (flat config supported)                 |
+| `eslint-config-prettier`             | **10.1.8**    | (flat config supported, v10+)           |
+| `eslint-plugin-prefer-arrow-functions` | **3.9.1**   | peer `eslint: >=9.17.0` (flat config)   |
+
+**ESLint 10 fully removes `.eslintrc.*` support** — there is no longer a
+backward-compat path. We must migrate to flat config; this is no longer
+optional.
+
+**TypeScript 6 breaking changes affecting us (none, but worth noting)**:
+- Removed `moduleResolution: "classic"` — we don't use it.
+- `esModuleInterop` and `allowSyntheticDefaultImports` cannot be set to false —
+  ours is true, fine.
+- `target: "es5"` and `"es3"` deprecated — ours is `es6`, fine.
+- Type-ID ordering changed for declaration emit; may affect `lib/index.d.ts`
+  byte-content. Behaviorally identical, but byte-diff'able. Monitor in
+  acceptance.
+
+**The `eslint-plugin-prefer-arrow` package is dead** (last published 2021-01,
+peer `eslint >=2.0.0`, no flat-config support). Replaced by
+`eslint-plugin-prefer-arrow-functions@3.9.1` which targets `eslint >=9.17.0`
+(flat config native). Rule name changes from `prefer-arrow/prefer-arrow-functions`
+to `prefer-arrow-functions/prefer-arrow-functions`.
+
+## Open Questions
+
+### Q1: Bump `engines.node` from `>=18` to `>=20`?
+
+**Recommendation: yes, bump to `>=20`.**
+
+Reasons:
+- Node 18 reached end-of-maintenance April 2025 (≈13 months ago as of design time).
+- Our CI matrix already only tests Node 20/22/24 — we don't actually verify the package on 18.
+- Vitest 4 and ESLint 10 both require Node 20+ for **development**. Keeping `engines.node: ">=18"` while requiring Node 20+ to develop produces a confusing split.
+- Aligns the consumer floor with the dev/CI floor. One mental model.
+
+Risk: a consumer running Node 18 will see an `EBADENGINE` warning on install (not a hard failure unless they've enabled strict-engines). That's a soft, intentional signal.
+
+This is a minor-version-bump worthy change (semver-minor for engines tightening). Recommend version bump to `1.1.0` when this design lands.
+
+### Q2: Vitest globals (no test-file changes) or explicit imports?
+
+**Recommendation: globals.**
+
+Vitest supports a `globals: true` option that exposes `describe`, `it`, `expect`, `beforeEach`, etc. as globals — Jest-compatible. The existing test files use these without imports; setting `globals: true` keeps them working unchanged.
+
+The alternative — adding `import { describe, it, expect, beforeEach } from 'vitest'` to every test file — is more explicit but requires touching every test file. For a small project with two test files, both options are fine. Globals wins on minimum-diff.
+
+The type tests (Unit 5) need an explicit `import { expectTypeOf, test } from 'vitest'` regardless, because `expectTypeOf` is not a global even with `globals: true`.
+
+### Q3: Keep coverage in default `npm test`?
+
+**Recommendation: yes, preserve current behavior.**
+
+The current Jest config runs with `--collectCoverage`. Vitest's equivalent is `vitest run --coverage`. Keeping coverage on by default in `npm test` matches existing behavior; a `test:fast` script for non-coverage runs can be added later if the maintainer wants it.
+
+### Q4: Version bump on landing?
+
+**Recommendation: `1.1.0` minor bump.**
+
+Rationale:
+- `engines.node` tightens from `>=18` to `>=20` — semver convention says minor bump.
+- TypeScript 6's declaration-emit ordering may produce a byte-different `lib/index.d.ts` even with no API changes; consumers' type cache may invalidate. Better to signal change with a minor than slip it into a patch.
+- All other changes are internal (devDeps, configs) and don't affect consumers.
+
+## Implementation Units
+
+### Unit 1: `package.json` — devDeps, scripts, engines
+
+**File**: `package.json`
+
+```jsonc
+{
+  // unchanged: name, version (will be 1.1.0 at release time), description,
+  //            main, types, repository, funding, keywords, author, license,
+  //            files, bugs, homepage, peerDependencies
+  "scripts": {
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "build": "tsc",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "lint": "eslint src",
+    "lint-fix": "eslint src --fix",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test && npm run lint",
+    "preversion": "npm run lint",
+    "version": "npm run format && git add -A src",
+    "postversion": "git push --follow-tags"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.13",
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "eslint": "^10.3.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-jsdoc": "^62.9.0",
+    "eslint-plugin-prefer-arrow-functions": "^3.9.1",
+    "express": "^4.18.1",
+    "prettier": "^3.8.3",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.1",
+    "vitest": "^4.1.5"
+  },
+  "peerDependencies": {
+    "@types/express": "^4.x",
+    "express": "^4.x"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}
+```
+
+**What's removed**:
+
+- `@types/jest` — Vitest has its own types
+- `jest`, `ts-jest` — replaced by Vitest
+- `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser` — replaced by unified `typescript-eslint` package
+- `eslint-plugin-prefer-arrow` — dead, replaced by `eslint-plugin-prefer-arrow-functions`
+- `eslint-plugin-react` — was unused (project has no React)
+- `tslint-config-prettier` — TSLint is dead
+
+**What's added**:
+
+- `vitest`, `@vitest/coverage-v8` — replaces Jest/ts-jest
+- `typescript-eslint` (unified package) — replaces the split `@typescript-eslint/*` v5 packages
+- `eslint-plugin-prefer-arrow-functions` — replaces dead `eslint-plugin-prefer-arrow`
+- `@types/node` — needed for Vitest config (uses `node:path` etc. transitively); pin to LTS-aligned `^22.0.0`
+
+**Implementation Notes**:
+
+- Keep all caret ranges; let lockfile pin exact versions on `npm install`.
+- The `lint` script drops `-c .eslintrc.js --ext .ts` flags. Flat config is auto-discovered (`eslint.config.js`) and ESLint 10 uses globs from the config itself; the `--ext` flag is gone in flat config.
+- `format:check` is a new script that fails if files aren't formatted (suitable for CI). `format` continues to be the write-mode for local use.
+- `engines.node` bumps to `>=20`. See Q1.
+
+**Acceptance Criteria**:
+
+- [ ] `npm install` succeeds with no peer-dep warnings (other than benign `eslint-plugin-jsdoc` warnings if any).
+- [ ] No `jest`, `ts-jest`, `@types/jest`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint-plugin-prefer-arrow`, `eslint-plugin-react`, or `tslint-config-prettier` in `node_modules` after install.
+- [ ] `engines.node` is `">=20"`.
+
+---
+
+### Unit 2: `eslint.config.js` — flat-config replacement
+
+**File**: `eslint.config.js` (new, ESM via `.js` with `export default`; works in CJS package because flat config files are evaluated by ESLint's loader, not Node's require)
+
+```javascript
+// @ts-check
+import tseslint from 'typescript-eslint';
+import preferArrowFunctions from 'eslint-plugin-prefer-arrow-functions';
+import jsdoc from 'eslint-plugin-jsdoc';
+import prettierConfig from 'eslint-config-prettier';
+
+export default tseslint.config(
+  // Ignore patterns (replaces .eslintignore)
+  {
+    ignores: ['lib/**', 'coverage/**', 'node_modules/**'],
+  },
+
+  // Base recommended configs
+  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+
+  // Project-wide config
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'prefer-arrow-functions': preferArrowFunctions,
+      jsdoc: jsdoc,
+    },
+    rules: {
+      // typescript-eslint rules carried forward from .eslintrc.js
+      '@typescript-eslint/array-type': ['error', { default: 'array' }],
+      '@typescript-eslint/consistent-type-assertions': 'error',
+      '@typescript-eslint/dot-notation': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/naming-convention': 'error',
+      '@typescript-eslint/no-empty-function': 'error',
+      '@typescript-eslint/no-empty-interface': 'error',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-misused-new': 'error',
+      '@typescript-eslint/no-namespace': 'error',
+      '@typescript-eslint/no-shadow': ['error', { hoist: 'all' }],
+      '@typescript-eslint/no-unused-expressions': 'error',
+      '@typescript-eslint/no-var-requires': 'error',
+      '@typescript-eslint/prefer-for-of': 'error',
+      '@typescript-eslint/prefer-function-type': 'error',
+      '@typescript-eslint/prefer-namespace-keyword': 'error',
+      '@typescript-eslint/triple-slash-reference': [
+        'error',
+        { path: 'always', types: 'prefer-import', lib: 'always' },
+      ],
+      '@typescript-eslint/unified-signatures': 'error',
+
+      // Replaced: ban-types is split in typescript-eslint v8 into multiple rules.
+      // Use no-restricted-types for the original Object/Function/Boolean/etc bans.
+      '@typescript-eslint/no-restricted-types': [
+        'error',
+        {
+          types: {
+            Object: { message: 'Avoid using `Object`. Did you mean `object`?' },
+            Function: {
+              message: 'Avoid `Function`. Prefer a specific function type, like `() => void`.',
+            },
+            Boolean: { message: 'Avoid `Boolean`. Did you mean `boolean`?' },
+            Number: { message: 'Avoid `Number`. Did you mean `number`?' },
+            String: { message: 'Avoid `String`. Did you mean `string`?' },
+            Symbol: { message: 'Avoid `Symbol`. Did you mean `symbol`?' },
+          },
+        },
+      ],
+
+      // Core ESLint rules carried forward
+      'constructor-super': 'error',
+      'dot-notation': 'error',
+      eqeqeq: ['error', 'smart'],
+      'guard-for-in': 'error',
+      'id-denylist': [
+        'error',
+        'any',
+        'Number',
+        'number',
+        'String',
+        'string',
+        'Boolean',
+        'boolean',
+        'Undefined',
+        'undefined',
+      ],
+      'id-match': 'error',
+      'max-classes-per-file': ['error', 1],
+      'no-bitwise': 'error',
+      'no-caller': 'error',
+      'no-cond-assign': 'error',
+      'no-console': 'error',
+      'no-debugger': 'error',
+      'no-empty': 'error',
+      'no-empty-function': 'error',
+      'no-eval': 'error',
+      'no-new-wrappers': 'error',
+      'no-throw-literal': 'error',
+      'no-undef-init': 'error',
+      'no-underscore-dangle': 'error',
+      'no-unsafe-finally': 'error',
+      'no-unused-expressions': 'error',
+      'no-unused-labels': 'error',
+      'no-var': 'error',
+      'object-shorthand': 'error',
+      'one-var': ['error', 'never'],
+      'prefer-const': 'error',
+      radix: 'error',
+      'spaced-comment': ['error', 'always', { markers: ['/'] }],
+      'use-isnan': 'error',
+
+      // Replacement plugin for the dead eslint-plugin-prefer-arrow
+      'prefer-arrow-functions/prefer-arrow-functions': 'error',
+
+      // jsdoc rules carried forward (newline-after-description was deprecated;
+      // dropped — its replacement is `tag-lines` which is more granular)
+      'jsdoc/check-alignment': 'error',
+      'jsdoc/check-indentation': 'error',
+    },
+  },
+
+  // Test files: relax type-checked rules for test ergonomics
+  {
+    files: ['src/**/__tests__/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-console': 'off',
+    },
+  },
+
+  // Prettier compat — must be last to override stylistic conflicts
+  prettierConfig,
+);
+```
+
+**Implementation Notes**:
+
+- **Why ESM in a CJS package**: ESLint flat config files are loaded by ESLint's own loader, not Node's `require()`. ESLint supports `eslint.config.js` with `export default` even in CJS packages. Alternative: `eslint.config.mjs`. Use `.js` because the project's `package.json` doesn't have `"type": "module"`, and ESLint 10 specifically allows `.js` flat-config in CJS projects.
+- **`projectService: true`** is the modern type-aware-linting setup in typescript-eslint v8 — replaces the old `project: 'tsconfig.eslint.json'` pattern. Auto-discovers projects via TypeScript's project service. **This eliminates the need for `tsconfig.eslint.json`**, which is deleted in Unit 7.
+- **`tseslint.config()` helper** is the official typed config builder from typescript-eslint v8. It accepts arrays/objects and returns a flat array. Provides type-checking on rule names.
+- **`tseslint.configs.recommended` and `recommendedTypeChecked`** are the v8 equivalents of the old `'plugin:@typescript-eslint/recommended'` + `'plugin:@typescript-eslint/recommended-requiring-type-checking'` extends. Names align.
+- **Test-files override block** consolidates the per-file `/* eslint-disable */` comments currently scattered across `src/__tests__/parser.test.ts` and `src/__tests__/example.test.ts`. With the test-files override, those comments can be removed (Unit 6).
+- **`ban-types` is split** in typescript-eslint v8. The original rule's "type bans" (Object, Function, etc.) are now `no-restricted-types`. Carried forward verbatim.
+- **`jsdoc/newline-after-description`** is deprecated in eslint-plugin-jsdoc v50+. Dropped (the replacement `tag-lines` is more granular; not needed for this codebase's minimal JSDoc).
+- The huge list of `"off"` rules in the old `.eslintrc.js` is dropped — they were cargo-culted from `tslint-to-eslint-config`'s autogenerator and are noise.
+
+**Acceptance Criteria**:
+
+- [ ] `npm run lint` runs against `src/` and produces no errors.
+- [ ] `npm run lint` reports the same set of issues that `eslint-plugin-prefer-arrow` would have caught (verifiable by introducing a non-arrow function in src/ and observing failure).
+- [ ] No `tsconfig.eslint.json` is referenced anywhere.
+- [ ] Type-aware rules (e.g. `@typescript-eslint/no-unsafe-call`) still fire for src/ but are silent for test files.
+
+---
+
+### Unit 3: `vitest.config.ts` — replaces `jestconfig.json`
+
+**File**: `vitest.config.ts` (new)
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.{test,spec}.{ts,tsx}', 'src/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/__tests__/**', 'src/**/*.{test,spec}.ts'],
+      reporter: ['text', 'html', 'lcov'],
+    },
+  },
+});
+```
+
+**Implementation Notes**:
+
+- **`globals: true`** — exposes `describe`, `it`, `expect`, `beforeEach` etc. as globals so existing test files need no import changes. See Q2.
+- **`include`** mirrors the original Jest `testRegex`. The original regex matched `__tests__/.*` plus `*.test.*`/`*.spec.*` anywhere; the Vitest globs cover both.
+- **`coverage.provider: 'v8'`** — uses native V8 coverage (faster than istanbul, no instrumentation). Requires `@vitest/coverage-v8` peer.
+- **Coverage `include`/`exclude`** carries forward Jest's `collectCoverageFrom: ['src/**/*']` minus test files (Vitest counts test files in coverage by default; we exclude them).
+- The config file is **TypeScript** — Vite-loaded, so it works without a separate transpile step regardless of the project's `"type"` field.
+
+**Acceptance Criteria**:
+
+- [ ] `npm test` runs all 30 existing tests and passes.
+- [ ] Coverage report is produced (terminal output + `coverage/` dir).
+- [ ] No imports needed in existing test files (`describe`/`it`/`expect` continue to work as globals).
+
+---
+
+### Unit 4: `tsconfig.json` updates
+
+**File**: `tsconfig.json`
+
+```jsonc
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./lib",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules/**/*", "**/__tests__/**/*", "lib/**/*"]
+}
+```
+
+**Implementation Notes**:
+
+- **One added line**: `"types": ["vitest/globals", "node"]` — required for `it`, `expect`, etc. to type-check at the source-file level when used as globals (Q2).
+- **`target: es6`** stays — TypeScript 6 still supports it (ES2015 = ES6 = `es6`). The `target: es5`/`es3` deprecations don't affect us.
+- **`module: commonjs`** stays — published lib continues as CJS.
+- **`exclude` adds `lib/**/*`** for safety; previously omitted but `outDir` content shouldn't be re-fed into the compiler.
+- **No `moduleResolution` field** — defaults to `"node"` for `module: commonjs`, which TS 6 still supports (the `"classic"` removal doesn't affect us).
+
+**Acceptance Criteria**:
+
+- [ ] `npm run build` produces `lib/index.js`, `lib/index.d.ts`, `lib/express-parser/index.js`, `lib/types/index.js`, etc. — same set as 1.0.6.
+- [ ] `lib/index.d.ts` exports the same identifiers as 1.0.6 (`parseExpressApp`, `Route`, `Layer`, `ExpressRegex`, `RouteMetaData`, `Parameter`, `Key`).
+- [ ] **Byte-content of `lib/` may differ** from 1.0.6 due to TS 6 type-ID ordering changes; that's acceptable as long as the type-level surface is equivalent. See Verification Checklist for the diff procedure.
+
+---
+
+### Unit 5: Public API type tests
+
+**File**: `src/__tests__/types.test-d.ts` (new)
+
+```typescript
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+  ExpressRegex,
+  Key,
+  Layer,
+  Parameter,
+  Route,
+  RouteMetaData,
+} from '../index';
+import { parseExpressApp } from '../index';
+import type { Express } from 'express';
+
+describe('public API type contract', () => {
+  it('parseExpressApp accepts an Express app and returns RouteMetaData[]', () => {
+    expectTypeOf(parseExpressApp).parameter(0).toEqualTypeOf<Express>();
+    expectTypeOf(parseExpressApp).returns.toEqualTypeOf<RouteMetaData[]>();
+  });
+
+  it('RouteMetaData has the documented shape', () => {
+    expectTypeOf<RouteMetaData>().toMatchObjectType<{
+      path: string | string[] | ExpressRegex;
+      pathParams: Parameter[];
+      method: string;
+      metadata?: any;
+    }>();
+  });
+
+  it('Parameter has the documented shape', () => {
+    expectTypeOf<Parameter>().toMatchObjectType<{
+      in: string;
+      name: string;
+      required: boolean;
+    }>();
+    // Allows arbitrary extra string keys
+    expectTypeOf<Parameter['extra' & string]>().toEqualTypeOf<any>();
+  });
+
+  it('Key has the documented shape', () => {
+    expectTypeOf<Key>().toEqualTypeOf<{
+      name: string;
+      optional: boolean;
+      offset: number;
+    }>();
+  });
+
+  it('ExpressRegex extends RegExp with fast-path flags', () => {
+    expectTypeOf<ExpressRegex>().toExtend<RegExp>();
+    expectTypeOf<ExpressRegex['fast_slash']>().toEqualTypeOf<boolean>();
+    expectTypeOf<ExpressRegex['fast_star']>().toEqualTypeOf<boolean>();
+  });
+
+  it('Route and Layer are exported (smoke check)', () => {
+    expectTypeOf<Route>().not.toBeNever();
+    expectTypeOf<Layer>().not.toBeNever();
+  });
+});
+```
+
+**Implementation Notes**:
+
+- **File extension `.test-d.ts`** is a Vitest convention for type-only tests — the suffix is recognized but doesn't actually change behavior; runtime assertions still execute. Use the suffix to signal intent.
+- **`expectTypeOf` is type-only**. It performs compile-time type-equality and shape checks. Tests pass if the types match; they fail at *typecheck time* with a TS error if they don't. So `npm run build` is what surfaces these failures, not `npm test` per se. But Vitest will also catch them when running.
+- **`toMatchObjectType` instead of `toEqualTypeOf`** for `RouteMetaData` and `Parameter` — `Parameter` has `[key: string]: any`, so strict equality with an object literal won't match. `toMatchObjectType` checks the documented shape is present without requiring exhaustive equality.
+- The `Parameter['extra' & string]` line verifies the index signature — a small extra check.
+
+**Acceptance Criteria**:
+
+- [ ] `npm test` includes `types.test-d.ts` in its run (verifiable by output).
+- [ ] All assertions pass against the current `src/index.ts` exports.
+- [ ] If someone changes `RouteMetaData['method']` from `string` to e.g. `'get' | 'post'`, the type test fails at typecheck time. Manually verify by introducing the change and observing the failure.
+
+---
+
+### Unit 6: Source code adjustments
+
+**File**: `src/express-parser/index.ts`, `src/__tests__/parser.test.ts`, `src/__tests__/example.test.ts`
+
+The existing per-file `/* eslint-disable ... */` headers reference rules that are now scoped:
+
+- **`src/express-parser/index.ts`** keeps its disables (they're for src code, not tests):
+
+  ```typescript
+  /* eslint-disable @typescript-eslint/no-unsafe-call */
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  /* eslint-disable no-underscore-dangle */
+  /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+  ```
+
+  Verify each is still triggered by removing it temporarily and seeing the lint failure. Drop any that no longer fire (e.g., `restrict-plus-operands` — verify if still needed).
+
+- **`src/__tests__/parser.test.ts`** and **`src/__tests__/example.test.ts`**: the eslint-disable headers can be **removed entirely** because the test-files override block in `eslint.config.js` (Unit 2) globally relaxes those rules for tests.
+
+**Implementation Notes**:
+
+- This unit is mechanical cleanup. Run lint, see what fires, adjust comments minimally.
+- The src/ disables exist because the parser does deep introspection of Express's internal layer/route structures, which are typed loosely (`any`-ish in `@types/express`). The disables are load-bearing.
+
+**Acceptance Criteria**:
+
+- [ ] `src/__tests__/*.test.ts` files have **no eslint-disable comments** at top.
+- [ ] `src/express-parser/index.ts` retains only the eslint-disable comments necessary to lint-clean (verified by toggling each).
+- [ ] `npm run lint` clean.
+
+---
+
+### Unit 7: Cleanup — delete obsolete files
+
+**Files to delete**:
+
+- `.eslintrc.js`
+- `tsconfig.eslint.json`
+- `jestconfig.json`
+
+**Implementation Notes**:
+
+- These files have functioning replacements in Units 2, 3, and 4 (tsconfig.eslint.json is no longer needed thanks to `projectService: true`).
+- ESLint 10 fully ignores `.eslintrc.*`, but leaving the file would be a confusing artifact — delete to avoid future maintainer confusion.
+
+**Acceptance Criteria**:
+
+- [ ] `test ! -f .eslintrc.js`
+- [ ] `test ! -f tsconfig.eslint.json`
+- [ ] `test ! -f jestconfig.json`
+- [ ] `npm run lint && npm test && npm run build` all pass after deletion.
+
+---
+
+## Implementation Order
+
+Strict dependency order:
+
+1. **Unit 1** — `package.json`. Establishes the dep set; `npm install` afterwards pulls new tooling.
+2. **Unit 4** — `tsconfig.json`. Quick edit; doesn't break anything but enables Unit 3's globals.
+3. **Unit 3** — `vitest.config.ts`. Tests can now run.
+4. **Unit 2** — `eslint.config.js`. Lint can now run.
+5. **Unit 6** — Source eslint-disable cleanup.
+6. **Unit 5** — Type tests (`types.test-d.ts`).
+7. **Unit 7** — Delete obsolete config files.
+8. **Verification** — Full `lint && build && test`, plus `lib/` diff vs 1.0.6 (see checklist).
+
+Why this order: tests run before lint runs before cleanup, so each step's verification is meaningful — if vitest.config breaks, you find out before refactoring lint config; if lint config breaks, you find out before deleting the old one.
+
+## Testing
+
+### Unit Tests
+
+All existing tests in `src/__tests__/parser.test.ts` and `src/__tests__/example.test.ts` continue to pass unchanged (Vitest API is Jest-compatible for the surface this project uses).
+
+### Type Tests: `src/__tests__/types.test-d.ts`
+
+Six test cases pinning:
+
+1. `parseExpressApp` parameter and return types
+2. `RouteMetaData` object shape
+3. `Parameter` object shape + index signature
+4. `Key` exact equality
+5. `ExpressRegex` extends RegExp + fast-path flag types
+6. `Route` and `Layer` smoke check
+
+These run as part of `npm test`. Failure modes:
+- **Compile failure**: type test asserts something that's no longer true → TS error → Vitest treats as test failure.
+- **Runtime pass**: `expectTypeOf` calls have no runtime effect, so passing the type check passes the test.
+
+### Coverage
+
+Coverage stays on by default in `npm test`. The HTML report lands in `coverage/` (added to `.gitignore` if not already).
+
+## Verification Checklist
+
+```bash
+# Unit 1: deps
+node -e "const p=require('./package.json'); if(p.engines.node !== '>=20') process.exit(1)"
+npm ls jest 2>&1 | grep -q '(empty)' && echo OK || echo "jest still installed"
+npm ls @typescript-eslint/eslint-plugin 2>&1 | grep -q '(empty)' && echo OK
+npm ls eslint-plugin-react 2>&1 | grep -q '(empty)' && echo OK
+
+# Units 2, 3, 4: configs run
+npm run lint
+npm test
+npm run build
+
+# Unit 5: type tests pinned
+grep -q 'expectTypeOf' src/__tests__/types.test-d.ts
+
+# Unit 7: old files gone
+test ! -f .eslintrc.js
+test ! -f tsconfig.eslint.json
+test ! -f jestconfig.json
+
+# Lib/ diff vs 1.0.6 — surfaces any TS-6 declaration churn
+git diff v1.0.6 -- lib/
+# Acceptable: byte differences in lib/index.d.ts due to type-ID ordering.
+# Not acceptable: missing exports, changed function signatures, narrowed types.
+# Spot-check by importing in a smoke project; or run the type tests against
+# the published lib/.
+
+# Format check
+npm run format:check
+```
+
+## Hardening Options (Not Implemented Now)
+
+- **Pin to exact versions** instead of caret ranges — reduces lockfile churn and ensures CI reproducibility but increases manual upgrade friction. Tradeoff worth revisiting.
+- **Add `arethetypeswrong` check** to CI — verifies the published `lib/index.d.ts` is consumable from both ESM and CJS consumers. Not strictly needed for a CJS-only package but cheap.
+- **Switch to `tsup` or similar for dual ESM+CJS** — out of scope; would belong in a separate "ESM publishing" design.
+- **Replace `globals: true` with explicit imports** in test files — better for tree-shaking and ESM purity, but requires editing every test file. Worth doing later.
+- **Add Husky / lint-staged** — runs lint+format on commit. Useful for solo maintainers; overkill for now.
+- **Snapshot test the `.d.ts` output** — would catch any future declaration drift programmatically rather than by manual diff.
+
+## References
+
+- TypeScript 6.0 release notes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html
+- ESLint 10 migration: https://eslint.org/docs/latest/use/migrate-to-10.0.0
+- typescript-eslint v8 flat config guide: https://typescript-eslint.io/getting-started/
+- Vitest config docs: https://vitest.dev/config/
+- `expectTypeOf` reference: https://vitest.dev/api/expect-typeof.html
+- `eslint-plugin-prefer-arrow-functions`: https://www.npmjs.com/package/eslint-plugin-prefer-arrow-functions

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+#
+# release.sh — cut a new release of express-route-parser end-to-end.
+#
+# Usage:
+#   ./scripts/release.sh patch              # 1.0.6 -> 1.0.7
+#   ./scripts/release.sh minor              # 1.0.6 -> 1.1.0
+#   ./scripts/release.sh major              # 1.0.6 -> 2.0.0
+#   ./scripts/release.sh 1.2.3              # explicit version
+#   ./scripts/release.sh patch --auto-merge # enable GitHub auto-merge after CI passes
+#   ./scripts/release.sh patch --no-watch   # don't watch the Release workflow run
+#
+# What it does (the full flow we use to publish):
+#
+#   1. Validates: clean tree, on main+up-to-date, gh CLI auth, no existing
+#      release branch for this version.
+#   2. Creates branch release/X.Y.Z, updates CHANGELOG.md date, bumps version
+#      in package.json and package-lock.json, commits.
+#   3. Pushes branch, opens PR via gh.
+#   4. Waits for CI checks to pass on the PR.
+#   5. Either auto-merges (--auto-merge) or pauses for the maintainer to merge.
+#   6. After merge, fetches main, tags the MERGE COMMIT (not the bump commit —
+#      see docs/RELEASING.md "Tag placement"), pushes the tag.
+#   7. Watches the Release workflow run, then verifies npm publication.
+#
+# Exit codes:
+#   0 — release shipped to npm successfully
+#   1 — precondition failed (dirty tree, wrong branch, etc.)
+#   2 — CI failed on the release PR
+#   3 — release workflow failed
+#   4 — npm verification failed (version not published, no provenance)
+#
+
+set -euo pipefail
+
+# -- Config -------------------------------------------------------------------
+
+readonly REPO_REMOTE="origin"
+readonly DEFAULT_BRANCH="main"
+readonly PACKAGE_NAME="express-route-parser"
+
+# -- Helpers ------------------------------------------------------------------
+
+color_red()    { printf '\033[0;31m%s\033[0m' "$*"; }
+color_green()  { printf '\033[0;32m%s\033[0m' "$*"; }
+color_yellow() { printf '\033[0;33m%s\033[0m' "$*"; }
+color_dim()    { printf '\033[2m%s\033[0m' "$*"; }
+
+step() { printf '\n%s %s\n' "$(color_green '==>')" "$*"; }
+info() { printf '%s %s\n' "$(color_dim '   ')" "$*"; }
+warn() { printf '%s %s\n' "$(color_yellow '!!!')" "$*" >&2; }
+die()  { printf '%s %s\n' "$(color_red 'ERROR:')" "$*" >&2; exit "${2:-1}"; }
+
+usage() {
+    sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# \?//' >&2
+    exit 64
+}
+
+# -- Argument parsing ---------------------------------------------------------
+
+BUMP=""
+AUTO_MERGE=0
+WATCH=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        patch|minor|major) BUMP="$1"; shift ;;
+        [0-9]*.[0-9]*.[0-9]*) BUMP="$1"; shift ;;  # explicit version
+        --auto-merge) AUTO_MERGE=1; shift ;;
+        --no-watch) WATCH=0; shift ;;
+        -h|--help) usage ;;
+        *) warn "Unknown argument: $1"; usage ;;
+    esac
+done
+
+[[ -z "$BUMP" ]] && usage
+
+# -- Preflight ----------------------------------------------------------------
+
+step "Preflight checks"
+
+command -v gh >/dev/null || die "gh CLI not found. Install: https://cli.github.com/"
+command -v jq >/dev/null || die "jq not found (used to compute next version)."
+command -v node >/dev/null || die "node not found."
+
+gh auth status >/dev/null 2>&1 || die "gh CLI not authenticated. Run: gh auth login"
+info "gh authenticated"
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$CURRENT_BRANCH" == "$DEFAULT_BRANCH" ]] || \
+    die "Must be on '$DEFAULT_BRANCH', currently on '$CURRENT_BRANCH'."
+info "on $DEFAULT_BRANCH"
+
+[[ -z "$(git status --porcelain)" ]] || \
+    die "Working tree is dirty. Stash or commit before releasing."
+info "working tree clean"
+
+git fetch "$REPO_REMOTE" "$DEFAULT_BRANCH" --quiet
+LOCAL_HEAD=$(git rev-parse HEAD)
+REMOTE_HEAD=$(git rev-parse "$REPO_REMOTE/$DEFAULT_BRANCH")
+[[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ]] || \
+    die "Local '$DEFAULT_BRANCH' is not up to date with '$REPO_REMOTE/$DEFAULT_BRANCH'. Run: git pull --ff-only"
+info "main up to date"
+
+# -- Compute version ----------------------------------------------------------
+
+step "Computing next version"
+
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+info "current version: $CURRENT_VERSION"
+
+case "$BUMP" in
+    patch|minor|major)
+        # Compute next version with node (no external semver dep needed).
+        NEW_VERSION=$(node -e "
+            const [maj, min, pat] = '$CURRENT_VERSION'.split('.').map(Number);
+            const bump = '$BUMP';
+            if (bump === 'major')      console.log(\`\${maj + 1}.0.0\`);
+            else if (bump === 'minor') console.log(\`\${maj}.\${min + 1}.0\`);
+            else                       console.log(\`\${maj}.\${min}.\${pat + 1}\`);
+        ")
+        ;;
+    *)
+        NEW_VERSION="$BUMP"
+        ;;
+esac
+
+info "new version: $(color_green "$NEW_VERSION")"
+
+RELEASE_BRANCH="release/$NEW_VERSION"
+RELEASE_TAG="v$NEW_VERSION"
+
+# Refuse to clobber an existing branch or tag.
+if git ls-remote --exit-code --heads "$REPO_REMOTE" "$RELEASE_BRANCH" >/dev/null 2>&1; then
+    die "Branch '$RELEASE_BRANCH' already exists on $REPO_REMOTE. Delete it or pick a different version."
+fi
+if git ls-remote --exit-code --tags "$REPO_REMOTE" "$RELEASE_TAG" >/dev/null 2>&1; then
+    die "Tag '$RELEASE_TAG' already exists on $REPO_REMOTE."
+fi
+
+# -- Create release branch ----------------------------------------------------
+
+step "Creating branch $RELEASE_BRANCH"
+
+git switch -c "$RELEASE_BRANCH"
+
+# Update CHANGELOG: replace YYYY-MM-DD placeholder if present, else move
+# [Unreleased] section under a dated [X.Y.Z] heading.
+TODAY=$(date -u +%Y-%m-%d)
+
+if grep -qE "## \[$NEW_VERSION\] - YYYY-MM-DD" CHANGELOG.md; then
+    info "CHANGELOG: filling date for pre-seeded [$NEW_VERSION]"
+    sed -i.bak "s/## \[$NEW_VERSION\] - YYYY-MM-DD/## [$NEW_VERSION] - $TODAY/" CHANGELOG.md
+    rm CHANGELOG.md.bak
+elif grep -qE "## \[$NEW_VERSION\] - [0-9]{4}-[0-9]{2}-[0-9]{2}" CHANGELOG.md; then
+    info "CHANGELOG: [$NEW_VERSION] section already dated, leaving as-is"
+else
+    warn "CHANGELOG.md has no [$NEW_VERSION] section."
+    warn "Add changes under [Unreleased] or pre-seed [$NEW_VERSION] before re-running."
+    git switch "$DEFAULT_BRANCH"
+    git branch -D "$RELEASE_BRANCH"
+    exit 1
+fi
+
+# Bump package.json and package-lock.json. The lockfile has the version in two
+# places (top-level "version" and packages."".version) — npm version covers both.
+info "bumping package.json + package-lock.json to $NEW_VERSION"
+npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version >/dev/null
+
+# Sanity: verify the bump landed in both files.
+PKG_VER=$(node -p "require('./package.json').version")
+LOCK_TOP=$(node -p "require('./package-lock.json').version")
+LOCK_PKGS=$(node -p "require('./package-lock.json').packages[''].version")
+[[ "$PKG_VER" == "$NEW_VERSION" && "$LOCK_TOP" == "$NEW_VERSION" && "$LOCK_PKGS" == "$NEW_VERSION" ]] || \
+    die "Version bump did not propagate consistently (pkg=$PKG_VER, lock-top=$LOCK_TOP, lock-pkgs=$LOCK_PKGS)."
+
+# Commit. Match prior convention: short message that's just the version.
+git add CHANGELOG.md package.json package-lock.json
+git commit -m "$NEW_VERSION" >/dev/null
+info "committed: $(git log -1 --oneline)"
+
+# -- Push and open PR ---------------------------------------------------------
+
+step "Pushing branch and opening PR"
+
+git push -u "$REPO_REMOTE" "$RELEASE_BRANCH" --quiet
+
+PR_BODY=$(cat <<EOF
+Release **$NEW_VERSION**.
+
+## Changelog
+
+See \`CHANGELOG.md\` for the full entry. Highlights:
+
+$(awk -v ver="$NEW_VERSION" '
+    $0 ~ "^## \\[" ver "\\]" { in_section = 1; next }
+    in_section && /^## \[/   { exit }
+    in_section && NF         { print }
+' CHANGELOG.md | head -40)
+
+## Test plan
+
+- [x] CI passes on this PR
+- [ ] After merge: tag points at the merge commit (script handles this)
+- [ ] After release: \`$NEW_VERSION\` shows on npm with provenance badge
+EOF
+)
+
+PR_URL=$(gh pr create --title "Release $NEW_VERSION" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1 | tail -1)
+info "PR: $PR_URL"
+
+PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+[[ -n "$PR_NUMBER" ]] || die "Could not parse PR number from: $PR_URL"
+
+# -- Wait for CI --------------------------------------------------------------
+
+step "Waiting for CI on PR #$PR_NUMBER"
+
+# Allow checks to register.
+sleep 5
+
+# Find the run ID(s) for this PR's CI.
+gh pr checks "$PR_NUMBER" >/dev/null 2>&1 || true
+
+# `gh pr checks --watch` blocks until terminal state.
+if ! gh pr checks "$PR_NUMBER" --watch --fail-fast 2>&1; then
+    die "CI failed on PR #$PR_NUMBER. Investigate: $PR_URL" 2
+fi
+
+info "CI passed"
+
+# -- Merge --------------------------------------------------------------------
+
+if [[ "$AUTO_MERGE" -eq 1 ]]; then
+    step "Enabling auto-merge"
+    gh pr merge "$PR_NUMBER" --auto --merge >/dev/null
+    info "auto-merge requested; will merge once branch protections are satisfied"
+else
+    step "Awaiting manual merge of PR #$PR_NUMBER"
+    info "Merge it: $PR_URL"
+    info "(use --auto-merge next time to skip this pause)"
+fi
+
+# Poll for merged state.
+SECONDS_WAITED=0
+while true; do
+    PR_STATE=$(gh pr view "$PR_NUMBER" --json state,mergedAt --jq '.state + "/" + (.mergedAt // "null")')
+    if [[ "$PR_STATE" == MERGED/* ]]; then
+        info "PR merged"
+        break
+    fi
+    if [[ "$PR_STATE" == CLOSED/null ]]; then
+        die "PR #$PR_NUMBER was closed without merging."
+    fi
+    SECONDS_WAITED=$((SECONDS_WAITED + 10))
+    if (( SECONDS_WAITED % 60 == 0 )); then
+        info "still waiting for merge ($((SECONDS_WAITED / 60))m)"
+    fi
+    sleep 10
+done
+
+# -- Tag the merge commit -----------------------------------------------------
+
+step "Tagging merge commit"
+
+git switch "$DEFAULT_BRANCH" >/dev/null 2>&1
+git pull --ff-only "$REPO_REMOTE" "$DEFAULT_BRANCH" --quiet
+
+# The merge commit IS the new HEAD of main (regardless of merge strategy:
+# squash/merge-commit/rebase all leave a single new commit at HEAD).
+MERGE_SHA=$(git rev-parse HEAD)
+info "tagging $MERGE_SHA as $RELEASE_TAG"
+
+git tag -a "$RELEASE_TAG" -m "$NEW_VERSION" "$MERGE_SHA"
+git push "$REPO_REMOTE" "$RELEASE_TAG" --quiet
+info "tag pushed: $RELEASE_TAG"
+
+# -- Watch release workflow ---------------------------------------------------
+
+if [[ "$WATCH" -eq 1 ]]; then
+    step "Watching Release workflow"
+
+    # Find the run that was just triggered.
+    sleep 5
+    RUN_ID=""
+    for _ in 1 2 3 4 5 6; do
+        RUN_ID=$(gh run list --workflow=release.yml --limit 1 --json databaseId,headBranch,event \
+            --jq ".[] | select(.event == \"push\") | .databaseId" | head -1)
+        [[ -n "$RUN_ID" ]] && break
+        sleep 5
+    done
+
+    if [[ -z "$RUN_ID" ]]; then
+        warn "Could not find Release workflow run; check manually: gh run list --workflow=release.yml"
+    else
+        info "run: https://github.com/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/actions/runs/$RUN_ID"
+        if ! gh run watch "$RUN_ID" --exit-status; then
+            die "Release workflow failed. Inspect: gh run view $RUN_ID --log-failed" 3
+        fi
+        info "Release workflow succeeded"
+    fi
+fi
+
+# -- Verify npm publication ---------------------------------------------------
+
+step "Verifying npm publication"
+
+# npm metadata lags briefly; poll for up to ~30s.
+for _ in 1 2 3 4 5 6; do
+    if npm view "$PACKAGE_NAME@$NEW_VERSION" version >/dev/null 2>&1; then
+        break
+    fi
+    sleep 5
+done
+
+PUBLISHED=$(npm view "$PACKAGE_NAME" dist-tags.latest 2>/dev/null || echo "")
+if [[ "$PUBLISHED" != "$NEW_VERSION" ]]; then
+    die "npm 'latest' is '$PUBLISHED', expected '$NEW_VERSION'." 4
+fi
+
+# Confirm provenance attestation is attached.
+HAS_PROVENANCE=$(npm view "$PACKAGE_NAME@$NEW_VERSION" --json 2>/dev/null \
+    | node -e "process.stdin.resume(); let d=''; process.stdin.on('data', c => d += c); process.stdin.on('end', () => { try { const j = JSON.parse(d); console.log(j.dist?.attestations ? 'yes' : 'no') } catch { console.log('unknown') } })")
+
+if [[ "$HAS_PROVENANCE" != "yes" ]]; then
+    warn "npm publish succeeded but provenance attestation not found ($HAS_PROVENANCE). Check the publish-job logs."
+else
+    info "provenance attestation present"
+fi
+
+# -- Done ---------------------------------------------------------------------
+
+step "$(color_green "Released $NEW_VERSION")"
+
+cat <<EOF
+  npm:    https://www.npmjs.com/package/$PACKAGE_NAME/v/$NEW_VERSION
+  github: https://github.com/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/releases/tag/$RELEASE_TAG
+
+If the GitHub Release notes don't reflect what shipped (e.g. tag was placed
+on a non-merge commit somehow), edit them with:
+
+  gh release edit $RELEASE_TAG --notes "..."
+EOF


### PR DESCRIPTION
Two independent improvements bundled in one PR because both are dev-tooling/docs only — no `lib/` change, no release needed.

## 1. One-command release script (`scripts/release.sh`)

Automates the release flow we used for 1.0.6:

```
./scripts/release.sh patch              # 1.0.6 -> 1.0.7
./scripts/release.sh minor --auto-merge # 1.0.6 -> 1.1.0, auto-merge after CI
./scripts/release.sh 1.2.3              # explicit version
```

What it does end-to-end:
- Preflight: clean tree, on `main` and up-to-date, `gh` authed, no clashing branch/tag.
- Creates `release/X.Y.Z`, fills CHANGELOG date, bumps `package.json` + `package-lock.json` (handles both lockfile locations).
- Pushes branch, opens PR with auto-generated body (pulls release highlights from CHANGELOG).
- Waits for CI on the PR.
- Pauses for manual merge (or `--auto-merge` enables GitHub auto-merge).
- After merge: fetches `main`, **tags the merge commit** (not the bump commit — see below), pushes tag.
- Watches the Release workflow run.
- Verifies npm publication and provenance attestation.

## 2. `docs/RELEASING.md` rewrite

The original runbook described `npm version` running directly on `main`, which doesn't work because `main` is protected. Rewritten to match the PR-based flow that actually ships releases.

Adds a **"Tag placement"** section documenting the lesson from 1.0.6: tagging the bump commit (inside the release PR's branch) makes the merge commit unreachable from the tag, so GitHub's auto-generated release notes miss the release PR's contents. Always tag the merge commit on `main`.

Adds **"Releasing With No Source Changes"** to discourage releasing for dev-only changes (like this PR).

## 3. `docs/design/devtools-modernization.md`

Design doc for the next dev-tooling overhaul (Vitest 4, TypeScript 6, ESLint 10 flat config, Prettier 3, `expectTypeOf` type tests). Versions verified directly from npm registry — TS is at 6.0.3, ESLint at 10.3, Vitest at 4.1 (training memory was stale across the board).

Key findings in the doc:
- ESLint 10 fully removes `.eslintrc.*`; flat-config migration is no longer optional.
- `eslint-plugin-prefer-arrow` is dead since 2021; replacement identified.
- Vitest 4 + ESLint 10 require Node 20+ for development. Doc proposes bumping `engines.node` from `>=18` to `>=20` (open question Q1).

This PR only adds the design — implementation is a separate ticket.

## Test plan

- [x] `bash -n scripts/release.sh` — syntax valid
- [x] `./scripts/release.sh --help` — usage prints correctly
- [ ] First real use will be the next release; that exercises the script end-to-end
- [x] CI passes on this PR