### PR TITLE
Release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-route-parser",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "express-route-parser",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-route-parser",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "An Express plugin that can list the path and route endpoints of an Express app.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/renderers.test.ts
+++ b/src/__tests__/renderers.test.ts
@@ -7,11 +7,7 @@ import type { AnyRouteMetaData } from '../renderers/serialize';
 import type { ExpressRegex } from '../types';
 
 // Helpers to build fixture routes
-const route = (
-  method: string,
-  path: string | string[] | ExpressRegex,
-  metadata?: unknown,
-): AnyRouteMetaData => ({
+const route = (method: string, path: string | string[] | ExpressRegex, metadata?: unknown): AnyRouteMetaData => ({
   method,
   path,
   pathParams: [],

--- a/src/renderers/html.ts
+++ b/src/renderers/html.ts
@@ -9,12 +9,7 @@ export interface HtmlRenderOptions {
 }
 
 const escapeHtml = (s: string): string =>
-  s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 
 const routeRow = (route: AnyRouteMetaData): string => {
   const method = route.method.toUpperCase();


### PR DESCRIPTION
Release **1.1.0**.

## Changelog

### Added
- `parseExpressApp(app, { multipleMetadata: true })` opt-in: returns `RouteMetaDataMulti[]` where `metadata: any[]` (always present, possibly empty). Default behavior unchanged. **Closes #6.**
- `withMetadata<M>(meta)` typed helper: returns `RequestHandler & { metadata: M }`. Eliminates the README's `const m: any = ...` cast pattern. **Closes #6.**
- `renderRoutesAsHtml`, `renderRoutesAsMarkdown`, `renderRoutesAsJson` — three pure-function renderers that turn parsed routes into a string. Self-contained HTML (inline CSS, no external deps), GFM-friendly Markdown table, JSON with `RegExp`-aware replacer. **Closes #5.**

### Fixed
- `parseExpressApp(app)` no longer crashes when called on an app with no routes registered (the `app.router` deprecated-getter trap in Express 4 — found during the test-quality pass).

### Changed
- `engines.node`: `>=18` → `>=20`. Required by Vitest 4 and ESLint 10's dev requirements; Node 18 reached end-of-maintenance April 2025.
- Dev tooling: Jest 28 + ts-jest → Vitest 4. TypeScript 4.7 → 6.0. ESLint 8 (`.eslintrc.js`) → ESLint 10 (flat config). Prettier 2 → 3.
- Single-mode error message for multiple metadata now mentions the `{ multipleMetadata: true }` opt-in.

### Removed
- Dead deps: `eslint-plugin-react`, `eslint-plugin-prefer-arrow`, `tslint-config-prettier`.
- Obsolete config files: `.eslintrc.js`, `tsconfig.eslint.json`, `jestconfig.json`.

## Test plan

- [x] CI passes on this PR
- [x] After merge: tag points at the merge commit (script handles this)
- [x] After release: `1.1.0` shows on npm with provenance badge