### PR TITLE
feat: Express 5 support (v2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on Express 4-only deployments. Disable via `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1`.
 - New export: `instrumentExpress5Router()` for users who need to defer instrumentation.
 
+### Fixed
+- **Express 5 nested-router `pathParams` now accumulate ancestor params**, matching Express 4
+  behavior. Previously, `app.use('/api/:v', router); router.get('/users/:id', h)` reported only
+  `:id`; now reports `:v` and `:id`. Closes a regression vs the v4 parser's existing semantics.
+
 ### Changed
 - **BREAKING (peer dep widening): `peerDependencies.express` is now `^4.x || ^5.x`** (was `^4.x`).
   Existing v1.x consumers on Express 4 are unaffected; Express 5 consumers can now install.
   Same widening for `@types/express`.
+- Express 5 optional-segment detection switched from a regex heuristic on the raw path string to
+  path-to-regexp v8's public `parse()` AST. `Group` tokens (`{...}`) are now the structural source
+  of optionality. Same observable behavior on documented forms; more robust on uncommon ones.
 - Internal restructure: parser body split into `src/express-parser/v4.ts`,
   `src/express-parser/v5.ts`, and a thin dispatcher in `src/express-parser/index.ts`.
   Public API surface unchanged.
+
+### Added (dev)
+- E2E test suite for the v5 surface (`docs/design/express-5-test-suite.md`): renderer integration
+  with real v5-parsed routes, README v5 example pin, cross-version (v4 + v5 in same process),
+  live HTTP smoke (boots a real v5 server, fetches each parsed route), import-order tests
+  (working + broken via sub-process fixtures), idempotent instrument, error middleware / 404
+  catchall / `router.param()` skipping, same-prefix mounts, all HTTP methods. Coverage:
+  117 → 173 tests.
+- Sub-process test fixtures live in `src/__tests__/fixtures/` (`.cjs`, exempt from eslint and
+  tsconfig).
 
 ## [1.1.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Express 5 support.** `parseExpressApp(app)` auto-detects Express 4 vs Express 5 and dispatches to
+  the appropriate parser. New `Parameter.type` field surfaces path-to-regexp v8's `'param'` vs
+  `'wildcard'` distinction for v5 routes.
+- Auto-installed `Router.prototype` patch on package import captures mount paths for Express 5
+  (necessary because Express 5 discards the path string at Layer construction). Idempotent; no-op
+  on Express 4-only deployments. Disable via `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1`.
+- New export: `instrumentExpress5Router()` for users who need to defer instrumentation.
+
+### Changed
+- **BREAKING (peer dep widening): `peerDependencies.express` is now `^4.x || ^5.x`** (was `^4.x`).
+  Existing v1.x consumers on Express 4 are unaffected; Express 5 consumers can now install.
+  Same widening for `@types/express`.
+- Internal restructure: parser body split into `src/express-parser/v4.ts`,
+  `src/express-parser/v5.ts`, and a thin dispatcher in `src/express-parser/index.ts`.
+  Public API surface unchanged.
+
 ## [1.1.0] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -171,7 +171,17 @@ const routes = parseExpressApp(app);
 
 Why: Express 5 stores mount paths only as compiled matcher closures; the original path string is unrecoverable after `Router.use(...)` returns. We patch `Router.prototype.use` and `.route` (auto-installed when this package is imported) to capture mount paths at registration time. The patch must be in place before any router is constructed.
 
-If your build sometimes constructs routers in modules imported before `express-route-parser`, set `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` and call `instrumentExpress5Router()` manually at the right time.
+If your build sometimes constructs routers in modules imported before `express-route-parser`, set `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` and call `instrumentExpress5Router()` manually at the right time:
+
+```typescript
+// EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1 must be set in the environment
+import { instrumentExpress5Router, parseExpressApp } from 'express-route-parser';
+
+instrumentExpress5Router();              // BEFORE any router is constructed
+import express from 'express';           // routers built after this point are captured
+```
+
+`instrumentExpress5Router()` is idempotent — calling it multiple times is safe and returns `true` after the first successful patch.
 
 ### Express 5 path-syntax notes
 

--- a/README.md
+++ b/README.md
@@ -150,3 +150,53 @@ app.get(
 );
 ```
 
+## Express 5 support
+
+`express-route-parser` works with Express 4 (since v1.0) and Express 5 (since v2.0). The same `parseExpressApp(app)` call works with either; the parser detects the version automatically.
+
+For Express 5, **import this package before constructing any routers**:
+
+```typescript
+// Top of your app entry point
+import { parseExpressApp } from 'express-route-parser';
+import express from 'express';                  // ← after our import
+
+const app = express();
+const router = express.Router();
+router.get('/users/:id', handler);
+app.use('/api', router);
+
+const routes = parseExpressApp(app);
+```
+
+Why: Express 5 stores mount paths only as compiled matcher closures; the original path string is unrecoverable after `Router.use(...)` returns. We patch `Router.prototype.use` and `.route` (auto-installed when this package is imported) to capture mount paths at registration time. The patch must be in place before any router is constructed.
+
+If your build sometimes constructs routers in modules imported before `express-route-parser`, set `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` and call `instrumentExpress5Router()` manually at the right time.
+
+### Express 5 path-syntax notes
+
+Express 5 uses `path-to-regexp@8`, which has different syntax than Express 4:
+
+| Express 4 | Express 5 |
+|---|---|
+| `/users/:id` | `/users/:id` (unchanged) |
+| `/users/:id?` | `/users{/:id}` |
+| `/files/*` | `/files/*splat` (named wildcard) |
+
+Migration is the consumer's job — Express 5 throws at registration time on the old syntax.
+
+### Extra parameter info on Express 5
+
+For routes parsed from an Express 5 app, each `Parameter` has a `type` field:
+
+```typescript
+interface Parameter {
+  name: string;
+  in: 'path';
+  required: boolean;
+  type?: 'param' | 'wildcard';   // present on v5 routes
+}
+```
+
+Express 4 routes don't populate `type` (the field is absent).
+

--- a/docs/design/express-5-support.md
+++ b/docs/design/express-5-support.md
@@ -1120,16 +1120,32 @@ test -f lib/express-parser/index.js
 npm run lint
 ```
 
-## Hardening Options (Not Implemented Now)
+## Hardening Options
 
-- **Surface ancestor-router params on the leaf `RouteMetaData`** — current v5 parser only emits the leaf route's own params (e.g., `/api/:v/users/:id` → `pathParams: [{ name: 'id' }]`, missing `:v`). The v4 parser carries ancestors. Worth fixing for parity in a follow-up.
-- **Parse path-to-regexp v8 keys structurally** instead of regex-detecting `{...}` for optionality. If/when v8 exposes a richer parse API, swap.
-- **Provide a public `instrumentExpress5Router()` re-export** if power users ask for it. Currently only available via deep import.
-- **Tests for `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` path** via spawned subprocess. Skipped in v1 because of in-process module-cache reuse complexity.
-- **TypeScript discriminated union** between `Parameter` (v4) and `Parameter5` (v5) — currently a single shape with optional `type`. Discriminated form would be more rigorous; less DX-friendly.
+### Implemented in 2.0.0
+
+- ~~**Surface ancestor-router params on the leaf `RouteMetaData`**~~ — done. v5 walker now
+  accumulates ancestor params per layer (`walkStack(stack, parent, parentParams[], ...)`),
+  matching v4 parity. See `src/express-parser/v5.ts`.
+- ~~**Parse path-to-regexp v8 keys structurally** instead of regex-detecting `{...}` for
+  optionality~~ — done. Replaced the `isOptional` heuristic with a walk over `parse()`'s
+  public AST. `Group` tokens are the structural source of optionality. See `extractParameters`
+  / `walkTokens` in `src/express-parser/v5.ts`.
+- ~~**Provide a public `instrumentExpress5Router()` re-export**~~ — done. Now exported from
+  `src/index.ts`.
+- ~~**Tests for `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` path** via spawned subprocess~~ —
+  done. See `src/__tests__/no-auto-instrument.test.ts` (env-var skip + manual instrument) and
+  `src/__tests__/import-order.test.ts` (import-order failure mode).
+
+### Still Deferred
+
+- **TypeScript discriminated union** between `Parameter` (v4) and `Parameter5` (v5) — currently
+  a single shape with optional `type`. Discriminated form would be more rigorous; less DX-friendly.
 - **Expose `instrument`'s patched-marker symbol** for testing tools that want to verify their setup.
-- **Compatibility for path-to-regexp v6/v7** (Express 4.21+ may use these in minor variations) — currently we only test against v0.x (Express 4.18) and v8 (Express 5.2).
-- **Renderer support for `Parameter.type`** — render wildcard/optional differently in HTML/Markdown. Probably worth doing as a follow-up minor.
+- **Compatibility for path-to-regexp v6/v7** (Express 4.21+ may use these in minor variations) —
+  currently we only test against v0.x (Express 4.18) and v8 (Express 5.2).
+- **Renderer support for `Parameter.type`** — render wildcard/optional differently in
+  HTML/Markdown. Probably worth doing as a follow-up minor.
 
 ## References
 

--- a/docs/design/express-5-support.md
+++ b/docs/design/express-5-support.md
@@ -1,0 +1,1140 @@
+# Design: Express 5 Support
+
+## Overview
+
+Adds Express 5 support to `express-route-parser` while keeping Express 4
+working unchanged. Ships as **2.0.0** (peer-dep widening = breaking under
+strict semver).
+
+**The headline insight from PoC research** (`/tmp/erp-express5-research/`):
+Express 5 stores `route.path` directly as a string — no regex tricks needed.
+The complex `pathRegexParser` / `mapKeysToPath` machinery from the v4 parser
+is unnecessary in v5. The only hard problem is mount-path recovery: Express 5
+discards the original mount-path string at `Layer` construction; only an
+opaque matcher closure survives. This design solves it via a **monkey-patch
+on `Router.prototype.use` / `.route`** that records the path argument at
+registration time. The patch is auto-installed when the package is imported.
+
+## Decisions Locked from User Q&A
+
+These were resolved before drafting; do not relitigate during implementation.
+
+| Question | Decision |
+| --- | --- |
+| Where is the monkey-patch installed? | **Auto-install on import** — side effect when any symbol is imported from the package. |
+| Express 4 or 5 only? | **Both** — peer dep `^4.x \|\| ^5.x`, runtime version detection. |
+| How to surface Express 5's richer path syntax? | **Add optional `type?: 'param' \| 'wildcard'` field** on `Parameter`. Non-breaking. |
+| Versioning? | **2.0.0** — peer-dep widening + new exports. |
+
+## Verified Facts (2026-05, queried directly)
+
+- Express 5 stable: `5.2.1`, requires Node `>=18` (no conflict with our `>=20`).
+- Express 5 routing lives in `router@^2.2.0`, which depends on `path-to-regexp@^8`.
+- `@types/express@5.0.6` published.
+- **Express 5 shape differences vs v4** (verified by inspecting `node_modules/router/lib/layer.js` and runtime probe):
+
+| Property | Express 4 | Express 5 / `router@2` |
+|---|---|---|
+| `app._router` | router object after first registration | `false` |
+| `app.router` | deprecated; **throws on access** | canonical access; returns the router function |
+| `layer.regexp` | always present, has `fast_slash`/`fast_star` | **`undefined`** |
+| `layer.keys` | `[{name, optional, offset}]` | always `[]` |
+| `layer.path` | n/a | always `undefined` at parse time (assigned during request matching) |
+| `layer.matchers` | n/a | array of opaque match closures (no source-recovery API) |
+| `layer.route.path` (leaf routes) | string | **string — same as v4** |
+| `layer.route.stack` (per-method) | same shape | **same shape — issue #7 fix logic transfers verbatim** |
+| Middleware `.metadata` field | discoverable | **discoverable — same** |
+
+- **Express 5 actively rejects Express 4 path syntax** at registration time
+  (e.g., `:name?` throws `PathError: Unexpected ?`). This is Express's
+  breaking change; our parser doesn't need to handle the old syntax for v5
+  apps because users physically can't register such paths.
+- **New Express 5 path syntax** users *can* write:
+  - `:param` — required path parameter (unchanged)
+  - `*splat` — named wildcard (was `*` in v4)
+  - `{:param}` — optional segment
+  - `{/:param}` — optional segment with leading slash
+  - `{...}` — optional groups
+- **`pathToRegexp(path).keys` from path-to-regexp v8** returns `[{ type: 'param' | 'wildcard', name: string }]` — directly usable for our `Parameter[]` extraction.
+
+## Out of Scope (Deferred)
+
+- **Async/promise route handler error semantics** — Express 5's auto-await behavior changes runtime behavior, not parser output. Nothing for us to do.
+- **`req.param()` deprecation** — irrelevant to parsing.
+- **`app.del()` removal** — already not referenced by our code.
+- **Rich param metadata beyond `type`** — splat repeat semantics, separator chars, custom patterns. The opt-in `richParams: true` mode floated in Q3 was rejected; staying with the simple `type?` extension.
+- **TypeScript types validating that the input is specifically Express 4 or 5.** We accept either via duck-typed `Express` parameter (current `import { Express } from 'express'` resolves to whichever is installed).
+
+## Implementation Units
+
+### Unit 1: Extend `Parameter` with optional `type`
+
+**File**: `src/types/index.ts`
+
+```typescript
+export interface Parameter {
+  in: string;
+  name: string;
+  required: boolean;
+  /**
+   * The kind of path parameter, when known. Populated for routes parsed from
+   * Express 5 (which exposes path-to-regexp v8's typed `keys` array). Absent
+   * for Express 4 routes — the v4 regex-recovery path doesn't preserve this
+   * distinction.
+   *
+   * - `'param'` — a normal `:name` segment (one path component)
+   * - `'wildcard'` — a `*splat` segment (zero or more path components)
+   */
+  type?: 'param' | 'wildcard';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+```
+
+**Implementation Notes**:
+
+- Strictly additive; the existing `Parameter` index signature already permits arbitrary extra keys, so adding `type?` is doubly non-breaking.
+- Marked optional so v4 consumers see no shape change.
+- Existing pinned type test (`types.test-d.ts:32`) uses `toMatchObjectType` and asserts the documented shape — this addition won't fail existing assertions, but a new assertion should pin the new field's allowed values.
+
+**Acceptance Criteria**:
+
+- [ ] `Parameter['type']` accepts `'param' | 'wildcard' | undefined`.
+- [ ] Existing `types.test-d.ts` assertions continue to pass.
+- [ ] New type-test pins `Parameter['type']` to the literal union.
+
+---
+
+### Unit 2: Auto-installed monkey-patch for `router@2.x`
+
+**File**: `src/express-parser/instrument.ts` (new)
+
+```typescript
+/**
+ * Express 5 / `router@^2.x` discards the original mount-path string at Layer
+ * construction time. To recover it, we patch `Router.prototype.use` and
+ * `.route` to record the path argument on the resulting Layer(s) before
+ * returning to the user. The patch is idempotent and a no-op for consumers
+ * who don't have the `router` package installed (Express 4 only).
+ *
+ * Side-effected by `src/index.ts` import so consumers don't need a setup
+ * call. Patches `Router.prototype` once; subsequent imports are no-ops.
+ */
+
+declare const Symbol: SymbolConstructor;
+
+const PATCHED_MARKER = Symbol.for('express-route-parser/patched');
+
+export interface CapturedPath {
+  /**
+   * The original path argument passed to `router.use(path, ...)` or
+   * `router.route(path)`. Stored on each newly-created Layer as a hidden
+   * symbol property so the v5 walker can reconstruct full paths.
+   */
+  path: string | RegExp | Array<string | RegExp>;
+}
+
+/**
+ * Hidden property attached to v5 Layer instances by the patch. The v5 parser
+ * reads this to recover mount paths. The symbol form prevents collisions
+ * with any Layer field upstream might add.
+ */
+export const ORIGINAL_PATH = Symbol.for('express-route-parser/originalPath');
+
+/**
+ * Idempotent. Returns true if patching took effect (or was already in place);
+ * false if the `router` package isn't installed (Express 4 only deployment).
+ *
+ * Exported for tests and for the documented escape hatch
+ * `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1`.
+ */
+export function instrumentExpress5Router(): boolean {
+  let routerModule: { prototype: RouterPrototype };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    routerModule = require('router');
+  } catch {
+    // No `router` package — Express 4-only consumer. Nothing to do.
+    return false;
+  }
+
+  const proto = routerModule.prototype as RouterPrototype & {
+    [PATCHED_MARKER]?: true;
+  };
+
+  if (proto[PATCHED_MARKER]) {
+    return true; // already patched; idempotent
+  }
+
+  const origUse = proto.use;
+  const origRoute = proto.route;
+
+  proto.use = function patchedUse(this: RouterStack, ...args: unknown[]): unknown {
+    const stackBefore = this.stack.length;
+    const ret = origUse.apply(this, args);
+    const path = pathArg(args[0]);
+    if (path !== undefined) {
+      for (let i = stackBefore; i < this.stack.length; i++) {
+        (this.stack[i] as RouterLayer)[ORIGINAL_PATH] = path;
+      }
+    }
+    return ret;
+  };
+
+  proto.route = function patchedRoute(this: RouterStack, path: string): unknown {
+    const ret = origRoute.call(this, path);
+    const newLayer = this.stack[this.stack.length - 1] as RouterLayer | undefined;
+    if (newLayer) newLayer[ORIGINAL_PATH] = path;
+    return ret;
+  };
+
+  Object.defineProperty(proto, PATCHED_MARKER, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+
+  return true;
+}
+
+function pathArg(first: unknown): string | RegExp | Array<string | RegExp> | undefined {
+  if (typeof first === 'string') return first;
+  if (first instanceof RegExp) return first;
+  if (Array.isArray(first) && first.every((p) => typeof p === 'string' || p instanceof RegExp)) {
+    return first as Array<string | RegExp>;
+  }
+  return undefined;
+}
+
+// Minimal duck-typed shapes for the parts of `router@2` we touch. Keeping
+// them local avoids a runtime dependency on the package's types.
+interface RouterPrototype {
+  use(...args: unknown[]): unknown;
+  route(path: string): unknown;
+}
+interface RouterStack {
+  stack: RouterLayer[];
+}
+interface RouterLayer {
+  [ORIGINAL_PATH]?: string | RegExp | Array<string | RegExp>;
+}
+
+// Side-effect: install on import unless explicitly disabled. The env-var
+// escape hatch is for unusual setups (lazy-loaded modules, test isolation).
+if (process.env.EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT !== '1') {
+  instrumentExpress5Router();
+}
+```
+
+**Implementation Notes**:
+
+- **Why a Symbol marker** for `PATCHED_MARKER` and `ORIGINAL_PATH`: prevents accidental collisions with any Layer property upstream might add. Symbols don't appear in `Object.keys` / `for...in` / `JSON.stringify`, so they're invisible to consumers.
+- **`Symbol.for('express-route-parser/patched')`** uses the global symbol registry. If our package is loaded twice through different paths (npm hoisting weirdness, monorepos), they share the same symbol and the idempotency check works correctly.
+- **`require('router')` inside try/catch** gracefully no-ops on Express 4-only consumers. Don't add `router` to our dependencies — let Express 5 bring it in transitively.
+- **Path arg extraction** rejects everything that isn't a string, RegExp, or array of either. Handlers (functions) passed as the first arg are correctly classified as "no mount path" — leaving `_origPath` undefined for those layers, which the walker treats as middleware (skipped).
+- **Env-var escape hatch** `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` is for users who need to defer instrumentation (e.g., loading our package after a router is already constructed somewhere). They'd then call `instrumentExpress5Router()` manually before parsing.
+- **`Object.defineProperty` for `PATCHED_MARKER`** makes it non-enumerable / non-writable / non-configurable, so a hostile third party can't easily un-patch.
+
+**Acceptance Criteria**:
+
+- [ ] Importing this module patches `Router.prototype.use` and `.route` exactly once, even if imported repeatedly.
+- [ ] If `router` package is not installed, import is a no-op (no thrown error).
+- [ ] After import, every Layer constructed via `router.use(path, ...)` or `router.route(path)` has the original path on `layer[ORIGINAL_PATH]`.
+- [ ] Layers constructed via `router.use(handler)` (no path arg) have `layer[ORIGINAL_PATH] === undefined`.
+- [ ] `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` skips the auto-install.
+- [ ] After patching, calling `instrumentExpress5Router()` again is a no-op (returns `true`).
+
+---
+
+### Unit 3: Express version detection
+
+**File**: `src/express-parser/detect.ts` (new)
+
+```typescript
+import type { Express } from 'express';
+
+export type ExpressVersion = 4 | 5 | 'unknown';
+
+export interface DetectionResult {
+  version: ExpressVersion;
+  /**
+   * The router object to walk. For v4, this is `app._router` (or `undefined`
+   * for routeless apps). For v5, this is `app.router` (the function itself
+   * has a `.stack` property).
+   */
+  router: { stack: unknown[] } | undefined;
+}
+
+/**
+ * Detects whether the given app is Express 4, Express 5, or neither.
+ *
+ * Heuristic:
+ * - Express 4: `app._router` is truthy after first route registration.
+ * - Express 5: `app._router` is `false`; `app.router` is a function with a `.stack`.
+ *
+ * For an Express 4 app with no routes registered, `app._router` is undefined
+ * AND accessing `app.router` throws (the deprecated 3.x→4.x tripwire). The
+ * try/catch handles this — we report `version: 4, router: undefined`, and the
+ * dispatcher returns an empty array (matching the post-1.1.0 fix behavior).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function detectExpressVersion(app: Express): DetectionResult {
+  const a = app as unknown as {
+    _router?: { stack: unknown[] } | false;
+    router?: { stack: unknown[] } | (() => unknown);
+  };
+
+  if (a._router && typeof a._router === 'object' && Array.isArray(a._router.stack)) {
+    return { version: 4, router: a._router };
+  }
+
+  // Express 5: `app.router` is the canonical access; in Express 4 reading it
+  // throws (deprecation tripwire). Wrap in try/catch.
+  try {
+    const r = a.router;
+    if (typeof r === 'function' && Array.isArray((r as unknown as { stack: unknown[] }).stack)) {
+      return { version: 5, router: r as unknown as { stack: unknown[] } };
+    }
+    if (r && typeof r === 'object' && Array.isArray((r as { stack: unknown[] }).stack)) {
+      return { version: 5, router: r as { stack: unknown[] } };
+    }
+  } catch {
+    // Express 4 with no routes registered: app._router is undefined AND
+    // app.router throws. Report v4 with no router.
+    return { version: 4, router: undefined };
+  }
+
+  return { version: 'unknown', router: undefined };
+}
+```
+
+**Implementation Notes**:
+
+- The `_router` truthy-and-object check is intentionally strict. Express 5 sets `app._router = false` (literal `false`); a naive truthy check would correctly reject it.
+- The try/catch around `app.router` is load-bearing: it's the Express 4 deprecation throw, which would otherwise crash detection on routeless v4 apps.
+- `'unknown'` covers neither shape — defensive; v2.0 will treat it as "no routes" and return `[]` (matching the routeless v4 behavior post-1.1.0).
+- The router object's `stack` array is typed `unknown[]` here because v4 and v5 layer shapes differ; the per-version walkers narrow it.
+
+**Acceptance Criteria**:
+
+- [ ] Returns `{ version: 4, router: <obj> }` for an Express 4 app with at least one registered route.
+- [ ] Returns `{ version: 4, router: undefined }` for an Express 4 app with no routes (the post-1.1.0 routeless case).
+- [ ] Returns `{ version: 5, router: <fn> }` for an Express 5 app (with or without routes — Express 5 always has a router function).
+- [ ] Does not throw on any input that's a valid Express 4 or 5 app.
+
+---
+
+### Unit 4: Move existing parser to `v4.ts`
+
+**File**: `src/express-parser/v4.ts` (renamed from `src/express-parser/index.ts`)
+
+Move the existing `ExpressPathParser` class, `parseRouteLayer`, `traverse`,
+`pathRegexParser`, `mapKeysToPath`, and `onlyForTesting` export verbatim. The
+top-level `parseExpressApp` overload signatures move to the new dispatcher
+(Unit 6).
+
+```typescript
+// File contents identical to current src/express-parser/index.ts EXCEPT:
+// - Rename the file to v4.ts
+// - Replace the public `parseExpressApp` with internal `parseV4`:
+export function parseV4(
+  app: Express,
+  options: ParseOptions,
+): RouteMetaData[] | RouteMetaDataMulti[] {
+  return new ExpressPathParser(app, options).appPaths;
+}
+// (or accept the already-detected router and skip the constructor's lookup)
+
+// Keep `onlyForTesting = { pathRegexParser, mapKeysToPath };` exported.
+```
+
+**Implementation Notes**:
+
+- This is a code move, not a rewrite. The 1.1.0 parser code stays correct for Express 4. Tests that depend on `onlyForTesting` import from `../express-parser/v4` instead of `../express-parser`.
+- Internal export `parseV4(app, options)` is consumed by the dispatcher in Unit 6. Keep `ExpressPathParser` as the underlying class.
+- The constructor's existing `app._router` lookup still works because the dispatcher only routes Express 4 apps to this code path. (It would also work for the routeless case since the constructor handles `undefined`.)
+
+**Acceptance Criteria**:
+
+- [ ] All 117 existing tests continue to pass without modification (other than test-file imports updating from `../express-parser` to `../express-parser/v4` for the `onlyForTesting` import).
+- [ ] No behavior change in v4 mode.
+
+---
+
+### Unit 5: New Express 5 parser
+
+**File**: `src/express-parser/v5.ts` (new)
+
+```typescript
+import type { Express } from 'express';
+import type {
+  RouteMetaData,
+  RouteMetaDataMulti,
+  Parameter,
+  ParseOptions,
+} from '../types';
+import { ORIGINAL_PATH } from './instrument';
+
+/**
+ * Parser for Express 5 / `router@^2.x` apps.
+ *
+ * Strategy: walk the router tree, joining captured mount paths
+ * (recorded by the `instrument` patch) with each `route.path`. Path-parameter
+ * extraction uses path-to-regexp v8's `pathToRegexp(path).keys`, which gives
+ * us `{ type: 'param' | 'wildcard', name: string }` directly — no regex
+ * source parsing.
+ */
+export function parseV5(
+  router: V5RouterStack,
+  options: ParseOptions,
+): RouteMetaData[] | RouteMetaDataMulti[] {
+  const out: Array<RouteMetaData | RouteMetaDataMulti> = [];
+  walkStack(router.stack, '', out, options.multipleMetadata === true);
+  return out as RouteMetaData[] & RouteMetaDataMulti[];
+}
+
+function walkStack(
+  stack: V5Layer[],
+  parent: string,
+  out: Array<RouteMetaData | RouteMetaDataMulti>,
+  multipleMetadata: boolean,
+): void {
+  for (const layer of stack) {
+    if (layer.route) {
+      emitRoute(layer, parent, out, multipleMetadata);
+    } else if (layer.handle && Array.isArray((layer.handle as V5RouterStack).stack)) {
+      const mountPath = layer[ORIGINAL_PATH];
+      if (mountPath === undefined && layer.name === 'router') {
+        // The patch wasn't installed before this router was constructed.
+        // Surface a clear error so users can fix the import order.
+        throw new Error(
+          'express-route-parser: Express 5 sub-router was constructed before instrumentation. ' +
+            'Import `express-route-parser` (or call `instrumentExpress5Router()`) before creating any routers.',
+        );
+      }
+      const newParent = mountPath !== undefined ? joinPath(parent, mountPathToString(mountPath)) : parent;
+      walkStack((layer.handle as V5RouterStack).stack, newParent, out, multipleMetadata);
+    }
+    // else: bare middleware — skipped
+  }
+}
+
+function emitRoute(
+  layer: V5Layer,
+  parent: string,
+  out: Array<RouteMetaData | RouteMetaDataMulti>,
+  multipleMetadata: boolean,
+): void {
+  if (!layer.route) return; // narrow
+
+  const mountPath = layer[ORIGINAL_PATH];
+  const routePathRaw = layer.route.path;
+  const fullPath = joinPath(
+    parent,
+    mountPath !== undefined ? mountPathToString(mountPath) : routePathRaw,
+  );
+  // If the mount path was captured (e.g., from .route(path)), the route's
+  // own .path is the same; fullPath above is correct. If the layer is a
+  // direct app.METHOD(path, ...) registration with no parent, fullPath is
+  // just `parent + route.path`.
+  const finalPath = mountPath !== undefined ? fullPath : joinPath(parent, routePathRaw);
+
+  const pathParams = extractParameters(routePathRaw);
+
+  // Group by HTTP method (issue #7 fix logic — same shape in v5)
+  const methodGroups = new Map<string, V5RouteEntry[]>();
+  for (const entry of layer.route.stack) {
+    if (!entry.method) continue;
+    const group = methodGroups.get(entry.method);
+    if (group) group.push(entry);
+    else methodGroups.set(entry.method, [entry]);
+  }
+
+  for (const [method, entries] of methodGroups) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const metaEntries = entries.filter((e) => (e?.handle as any)?.metadata !== undefined);
+
+    if (multipleMetadata) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const metadata = metaEntries.map((e) => (e.handle as any).metadata);
+      out.push({ path: finalPath, pathParams, method, metadata });
+    } else {
+      if (metaEntries.length > 1) {
+        throw new Error(
+          'Only one metadata middleware is allowed per route. ' +
+            'Pass { multipleMetadata: true } to parseExpressApp() to allow multiple.',
+        );
+      }
+      if (metaEntries.length === 0) {
+        out.push({ path: finalPath, pathParams, method });
+      } else {
+        out.push({
+          path: finalPath,
+          pathParams,
+          method,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          metadata: (metaEntries[0].handle as any).metadata,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Extract path parameters from an Express 5 route path string using
+ * path-to-regexp v8. Returns an empty array for paths with no parameters
+ * or for non-string (regex / array) paths — those aren't parsed for params.
+ */
+function extractParameters(path: string | RegExp | Array<string | RegExp>): Parameter[] {
+  if (typeof path !== 'string') return [];
+
+  // Lazy-require so we don't load path-to-regexp on Express 4-only deployments.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { pathToRegexp } = require('path-to-regexp') as {
+    pathToRegexp: (
+      p: string,
+    ) => { regexp: RegExp; keys: Array<{ type: 'param' | 'wildcard'; name: string }> };
+  };
+
+  let parsed: { keys: Array<{ type: 'param' | 'wildcard'; name: string }> };
+  try {
+    parsed = pathToRegexp(path);
+  } catch {
+    // Path-to-regexp v8 throws on syntactically invalid paths. Fall back to
+    // empty params; the user's paths are their problem.
+    return [];
+  }
+
+  return parsed.keys.map((k) => ({
+    name: k.name,
+    in: 'path',
+    // path-to-regexp v8 doesn't model "optional" as a flag on the key; an
+    // optional segment in the path source produces a param with the same shape
+    // but the segment is wrapped in `{...}`. Detecting that requires a second
+    // pass on the raw source. For v1 of this design: report `required: true`
+    // for non-wildcard params unless we can detect optional (see implementation note).
+    required: k.type !== 'wildcard' && !isOptional(path, k.name),
+    type: k.type,
+  }));
+}
+
+/**
+ * Heuristic: detect if a named segment appears inside `{...}` in the path
+ * source. path-to-regexp v8 expresses optional segments via `{...}` wrappers
+ * around the segment; the segment's `key.name` is preserved.
+ *
+ * Examples:
+ *   '/users/:id'             — id NOT optional
+ *   '/users/{:id}'           — id optional
+ *   '/users{/:id}'           — id optional with leading slash
+ *   '/files/*splat'          — splat (separately classified as wildcard)
+ *   '/files/{*splat}'        — wildcard, also optional in zero-match sense
+ */
+function isOptional(rawPath: string, name: string): boolean {
+  // Find a `{...}` group containing `:name` or `*name`.
+  const re = new RegExp('\\{[^}]*[:*]' + escapeRegex(name) + '[^a-zA-Z0-9_]', 'g');
+  const altRe = new RegExp('\\{[^}]*[:*]' + escapeRegex(name) + '\\}', 'g');
+  return re.test(rawPath) || altRe.test(rawPath);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function joinPath(parent: string, child: string): string {
+  if (!parent) return child || '/';
+  if (!child || child === '/') return parent;
+  return (parent + child).replace(/\/{2,}/g, '/');
+}
+
+function mountPathToString(p: string | RegExp | Array<string | RegExp>): string {
+  if (typeof p === 'string') return p;
+  if (p instanceof RegExp) return p.toString();
+  // Array form: match v4 parser's existing behavior — join with comma.
+  return p.map((x) => (typeof x === 'string' ? x : x.toString())).join(',');
+}
+
+// ---- Local duck-typed shapes for v5 / router@2 layers ----
+
+interface V5RouterStack {
+  stack: V5Layer[];
+}
+
+interface V5Layer {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handle?: ((...args: any[]) => unknown) | V5RouterStack;
+  route?: {
+    path: string;
+    stack: V5RouteEntry[];
+  };
+  [ORIGINAL_PATH]?: string | RegExp | Array<string | RegExp>;
+}
+
+interface V5RouteEntry {
+  method?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handle?: any;
+}
+```
+
+**Implementation Notes**:
+
+- **Lazy-require `path-to-regexp`** so Express 4-only consumers don't pay for it. Falls under the same "no runtime dep" principle as the `router` lazy-require in `instrument.ts`.
+- **`isOptional` heuristic**: path-to-regexp v8's `keys` array doesn't carry optionality info — it's syntactic, expressed in the path string via `{...}` wrappers. Detecting it requires re-scanning the raw source. The regex-based detection covers the common forms (`{:name}`, `{/:name}`, `{:name}suffix`, etc.) but is heuristic. If path-to-regexp v8 ever exposes structural parsing output, swap to that.
+- **Mount-path missing check** is the user-facing failure mode for "patch wasn't installed early enough". Throws with actionable instructions.
+- **The `finalPath` computation** has a subtle wrinkle: for routes registered via `router.route('/x').get(...)`, the route layer's `_origPath` and `route.path` are the same string. Joining mount-prefix+`/x` is correct. For routes registered via `router.get('/x', ...)`, the route layer's `_origPath` is `/x` and `route.path` is also `/x`. Either way `joinPath(parent, route.path)` is correct. The duplicated computation is defensive.
+- **Multi-metadata branch matches v4 behavior verbatim** — the design is: same `RouteMetaData` / `RouteMetaDataMulti` output, regardless of source Express version.
+
+**Acceptance Criteria**:
+
+- [ ] An Express 5 app with no routes returns `[]`.
+- [ ] An Express 5 app with a top-level `app.get('/x/:id', h)` returns one entry: `{ path: '/x/:id', method: 'get', pathParams: [{ name: 'id', in: 'path', required: true, type: 'param' }] }`.
+- [ ] Nested `app.use('/api/:v', router); router.get('/x', h)` returns `path: '/api/:v/x'`.
+- [ ] Two-level nesting works (`app.use('/a', r1); r1.use('/b', r2); r2.get('/c', h)` → `/a/b/c`).
+- [ ] Wildcard path `/files/*splat` produces `pathParams[0]` with `type: 'wildcard'`, `required: false`.
+- [ ] Optional segment `/users/{:id}` produces `pathParams[0]` with `required: false`.
+- [ ] Multiple methods on `router.route('/x').get().post()` produce two entries (issue #7 logic transfers).
+- [ ] `multipleMetadata: true` returns `metadata: any[]` shape.
+- [ ] If a sub-router was constructed before instrument was loaded, throws a clear actionable error.
+- [ ] Regex mount paths `/api(/v\d+)/` and array mount paths `['/v1','/v2']` produce sensible string-form path output (matching v4 conventions).
+
+---
+
+### Unit 6: Dispatcher
+
+**File**: `src/express-parser/index.ts` (rewrite — no longer holds the parser body)
+
+```typescript
+import type { Express } from 'express';
+import type { RouteMetaData, RouteMetaDataMulti, ParseOptions } from '../types';
+import { detectExpressVersion } from './detect';
+import { parseV4 } from './v4';
+import { parseV5 } from './v5';
+
+/**
+ * Parses an Express app and returns its routes with metadata. Auto-detects
+ * Express 4 vs Express 5; works with both. For Express 5, requires that
+ * `express-route-parser` was imported before any router was constructed
+ * (the auto-installed instrumentation captures mount paths at that time).
+ */
+export function parseExpressApp(
+  app: Express,
+  options?: { multipleMetadata?: false },
+): RouteMetaData[];
+export function parseExpressApp(
+  app: Express,
+  options: { multipleMetadata: true },
+): RouteMetaDataMulti[];
+export function parseExpressApp(
+  app: Express,
+  options: ParseOptions = {},
+): RouteMetaData[] | RouteMetaDataMulti[] {
+  const detection = detectExpressVersion(app);
+
+  if (detection.router === undefined) {
+    return [] as RouteMetaData[] & RouteMetaDataMulti[];
+  }
+
+  if (detection.version === 4) {
+    return parseV4(app, options);
+  }
+
+  if (detection.version === 5) {
+    // The detection result already gave us the v5 router; pass it directly so
+    // v5.ts doesn't re-do the lookup.
+    return parseV5(detection.router as Parameters<typeof parseV5>[0], options);
+  }
+
+  // 'unknown' — defensive: treat as no routes.
+  return [] as RouteMetaData[] & RouteMetaDataMulti[];
+}
+```
+
+**Implementation Notes**:
+
+- Same overload shape as 1.x — public API surface is unchanged.
+- The dispatcher does NOT re-run the `app._router` / `app.router` lookup; it trusts `detectExpressVersion`'s result. v4 and v5 walkers each take a router object and walk it.
+- `parseV4` accepts `(app, options)` because the existing class still does its own router lookup; that's fine — the `_router` it finds is the same one the dispatcher detected. Could be tightened later by passing the router in directly.
+- The `'unknown'` branch is genuinely unreachable in practice (any app with `_router: false` AND no `app.router` function isn't an Express app), but the explicit return keeps the function total.
+
+**Acceptance Criteria**:
+
+- [ ] All 117 existing tests pass — `parseExpressApp(v4App)` works as before.
+- [ ] `parseExpressApp(v5App)` works (covered by Unit 5's tests).
+- [ ] `parseExpressApp(routelessV4App)` returns `[]` (1.1.0 fix preserved).
+- [ ] `parseExpressApp(routelessV5App)` returns `[]`.
+- [ ] Public type signatures unchanged (overload selection via `multipleMetadata` still works).
+
+---
+
+### Unit 7: Top-level export — ensure instrument runs
+
+**File**: `src/index.ts`
+
+```typescript
+// Side-effect import: auto-install the Router prototype patch for Express 5
+// before any user-imported router can be constructed. Loading this module
+// before `express` works in typical apps where imports are at module top.
+import './express-parser/instrument';
+
+export { parseExpressApp } from './express-parser';
+export { withMetadata } from './with-metadata';
+export * from './types';
+export * from './renderers';
+```
+
+**Implementation Notes**:
+
+- The `import './express-parser/instrument'` line is the ONLY change. Its module body's `if (process.env.EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT !== '1') instrumentExpress5Router();` runs as a side effect.
+- The fact that this is the *first* import means the patch is applied before any other `express-route-parser` symbol resolves, which is before any user code that imports from us runs.
+- `instrument.ts` doesn't re-export anything to the public API by default. Power users who need the manual escape hatch can `import { instrumentExpress5Router } from 'express-route-parser/lib/express-parser/instrument'` — deep import; not officially public, but not blocked either. If demand exists, we can re-export from index.ts in a future minor.
+
+**Acceptance Criteria**:
+
+- [ ] Importing `parseExpressApp` (or any other symbol) from `'express-route-parser'` causes `Router.prototype.use` and `.route` to be patched (verifiable via the `Symbol.for('express-route-parser/patched')` marker).
+
+---
+
+### Unit 8: `package.json` updates
+
+**File**: `package.json`
+
+```jsonc
+{
+  // unchanged: name, description, main, types, scripts, repo, funding, etc.
+  "version": "1.1.0",  // bumped at release time to 2.0.0 via release script
+
+  "peerDependencies": {
+    "@types/express": "^4.x || ^5.x",
+    "express": "^4.x || ^5.x"
+  },
+
+  "devDependencies": {
+    // existing devDeps unchanged...
+
+    // The default `express` devDep stays at v4 so existing tests don't churn:
+    "@types/express": "^4.17.13",
+    "express": "^4.18.1",
+
+    // Add v5 alongside via npm aliases for parallel testing:
+    "express-v5": "npm:express@^5.2.0",
+    "@types/express-v5": "npm:@types/express@^5.0.0",
+
+    // Required for v5 path-param extraction in tests; transitively present
+    // via express-v5, but listing it explicitly clarifies the dep.
+    "path-to-regexp": "^8.0.0"
+  },
+
+  "engines": {
+    "node": ">=20"
+  }
+}
+```
+
+**Implementation Notes**:
+
+- **Peer dep widens** to `^4.x || ^5.x`. Consumers install one. Both type packages widen the same way.
+- **`express-v5` and `@types/express-v5` are npm aliases** — the same name `express` published under a different local name. Lets us have both `express@4` and `express@5` available in tests.
+- **No new dependencies on production**. Both `router` and `path-to-regexp` come in transitively when consumers install Express 5.
+- **`engines.node` stays at `>=20`** (Express 5's `>=18` is stricter-than-our-floor; aligning at 20 is safe).
+- **`devDependencies.express` stays at v4** so the existing tests run without modification. v5-specific tests use `import express from 'express-v5'`.
+
+**Acceptance Criteria**:
+
+- [ ] `npm install` succeeds with the updated devDeps.
+- [ ] `import express from 'express-v5'` resolves to express@5.x in test files.
+- [ ] `import express from 'express'` continues to resolve to express@4.x (existing test imports unchanged).
+- [ ] `peerDependencies` widening reflected.
+
+---
+
+### Unit 9: Tests — Express 5 suite
+
+**File**: `src/__tests__/parser-v5.test.ts` (new)
+
+```typescript
+// Note: this file uses the `express-v5` npm alias (see package.json).
+// The package's auto-instrument side effect runs when we import from the lib.
+import { describe, it, expect, beforeEach } from 'vitest';
+import express, { type Express, type Request, type Response, type NextFunction, type RequestHandler } from 'express-v5';
+import { parseExpressApp, withMetadata } from '../index';
+
+describe('Express 5 parser', () => {
+  let app: Express;
+  const ok: RequestHandler = (_req, res) => {
+    res.status(204).send();
+  };
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  // --- Coverage parity with the v4 suite ------------------------------------
+
+  it('returns [] for an Express 5 app with no routes', () => {
+    expect(parseExpressApp(app)).toEqual([]);
+  });
+
+  it('parses a single top-level route', () => {
+    app.get('/health', ok);
+    expect(parseExpressApp(app)).toEqual([
+      { path: '/health', method: 'get', pathParams: [] },
+    ]);
+  });
+
+  it('extracts a required path parameter with type info', () => {
+    app.get('/users/:id', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.path).toBe('/users/:id');
+    expect(route.pathParams).toEqual([
+      { name: 'id', in: 'path', required: true, type: 'param' },
+    ]);
+  });
+
+  it('parses an optional segment using v5 syntax {:name}', () => {
+    app.get('/users{/:id}', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.pathParams[0].name).toBe('id');
+    expect(route.pathParams[0].required).toBe(false);
+    expect(route.pathParams[0].type).toBe('param');
+  });
+
+  it('parses a wildcard segment as type "wildcard"', () => {
+    app.get('/files/*splat', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.pathParams).toEqual([
+      { name: 'splat', in: 'path', required: false, type: 'wildcard' },
+    ]);
+  });
+
+  it('parses nested sub-routers and joins mount paths', () => {
+    const router = express.Router();
+    const sub = express.Router();
+    sub.get('/inner/:thing', ok);
+    router.use('/sub/:tenant', sub);
+    app.use('/api/:version', router);
+
+    const parsed = parseExpressApp(app);
+    expect(parsed).toEqual([
+      {
+        path: '/api/:version/sub/:tenant/inner/:thing',
+        method: 'get',
+        pathParams: [
+          { name: 'thing', in: 'path', required: true, type: 'param' },
+        ],
+      },
+    ]);
+    // Note: pathParams reflects the LEAF route's own params, not the
+    // ancestors' — matching existing v4 behavior. (This may be a separate
+    // gap to address later, but it preserves parity.)
+  });
+
+  it('parses Router#route().get().post() as separate entries (issue #7 parity)', () => {
+    app.route('/users').get(ok).post(ok);
+    expect(parseExpressApp(app)).toEqual([
+      { path: '/users', method: 'get', pathParams: [] },
+      { path: '/users', method: 'post', pathParams: [] },
+    ]);
+  });
+
+  it('throws on multiple metadata middlewares in single mode', () => {
+    app.get('/x', withMetadata({ a: 1 }), withMetadata({ b: 2 }), ok);
+    expect(() => parseExpressApp(app)).toThrow(/multipleMetadata: true/);
+  });
+
+  it('returns metadata: any[] in multipleMetadata mode', () => {
+    app.get('/x', withMetadata({ a: 1 }), withMetadata({ b: 2 }), ok);
+    const [route] = parseExpressApp(app, { multipleMetadata: true });
+    expect(route.metadata).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('handles regex mount path', () => {
+    const r = express.Router();
+    r.get('/inner', ok);
+    app.use(/^\/api/, r);
+    expect(() => parseExpressApp(app)).not.toThrow();
+    const parsed = parseExpressApp(app);
+    expect(parsed.length).toBeGreaterThanOrEqual(1);
+    expect(parsed[0].method).toBe('get');
+  });
+
+  it('handles array mount path', () => {
+    const r = express.Router();
+    r.get('/inner', ok);
+    app.use(['/v1', '/v2'], r);
+    expect(() => parseExpressApp(app)).not.toThrow();
+    const parsed = parseExpressApp(app);
+    expect(parsed.length).toBeGreaterThanOrEqual(1);
+    expect(parsed[0].method).toBe('get');
+  });
+
+  it('HEAD method round-trip', () => {
+    app.head('/health', ok);
+    expect(parseExpressApp(app)[0].method).toBe('head');
+  });
+
+  it('OPTIONS method round-trip', () => {
+    app.options('/cors', ok);
+    expect(parseExpressApp(app)[0].method).toBe('options');
+  });
+
+  it('mounted empty router produces no entries', () => {
+    const empty = express.Router();
+    app.use('/empty', empty);
+    expect(parseExpressApp(app)).toEqual([]);
+  });
+
+  it('withMetadata round-trips through v5 parser', () => {
+    app.get('/x', withMetadata({ op: 'getX' }), ok);
+    const [route] = parseExpressApp(app);
+    expect(route.metadata).toEqual({ op: 'getX' });
+  });
+});
+
+describe('Express 5 — instrument behavior', () => {
+  it('throws a helpful error when a router was constructed before instrumentation', () => {
+    // This is hard to test in-process because the instrument is auto-installed
+    // on import. Use a child-process pattern: spawn a script that disables
+    // auto-instrument, builds a router, then imports our package and parses.
+    // See `parser-v5.test.ts` companion fixture or use `vi.mock`.
+    // For v1: skip the negative case here and cover it via a separate test
+    // file that uses `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1`.
+  });
+});
+```
+
+**Implementation Notes**:
+
+- File uses `import express from 'express-v5'` to pin the v5 alias. `import { parseExpressApp, withMetadata }` from our lib pulls the same package — `path-to-regexp` v8 lazy-require fires inside `extractParameters`.
+- The "instrument missing" negative test is genuinely awkward to write in-process (the side effect already ran). Plan: a small companion test file using `vi.spawn` or a separate child-process fixture. Stub for v1; harden later.
+- The pathParams ancestry caveat noted: v4 parser surfaces ALL keys from the regex chain (mount + route); v5 parser as designed surfaces only the leaf route's params. This is a parity gap worth addressing — added to "Hardening Options" below.
+
+**Acceptance Criteria**:
+
+- [ ] All assertions pass against express@5.2.x.
+- [ ] No new test failures in the existing v4 suite (test files import from `'express'` which stays v4).
+
+---
+
+### Unit 10: Type tests for new exports
+
+**File**: `src/__tests__/types.test-d.ts` (extend)
+
+Add:
+
+```typescript
+describe('Express 5 type extensions', () => {
+  it('Parameter.type accepts the documented union or undefined', () => {
+    type T = Parameter['type'];
+    expectTypeOf<T>().toEqualTypeOf<'param' | 'wildcard' | undefined>();
+  });
+
+  it('Existing Parameter shape with new field still satisfies toMatchObjectType', () => {
+    expectTypeOf<Parameter>().toMatchObjectType<{
+      in: string;
+      name: string;
+      required: boolean;
+    }>();
+  });
+});
+```
+
+**Acceptance Criteria**:
+
+- [ ] `expectTypeOf<Parameter['type']>().toEqualTypeOf<'param' | 'wildcard' | undefined>()` passes.
+- [ ] Existing 12 type tests in this file continue to pass.
+
+---
+
+### Unit 11: README + CHANGELOG
+
+**File**: `README.md` (extend, add a "Express 5" section)
+
+```markdown
+## Express 5 support
+
+`express-route-parser` works with Express 4 (since v1.0) and Express 5 (since v2.0). The same `parseExpressApp(app)` call works with either; the parser detects the version automatically.
+
+For Express 5, **import this package before constructing any routers**:
+
+\`\`\`typescript
+// Top of your app entry point
+import { parseExpressApp } from 'express-route-parser';
+import express from 'express';                  // ← after our import
+
+const app = express();
+const router = express.Router();
+router.get('/users/:id', handler);
+app.use('/api', router);
+
+const routes = parseExpressApp(app);
+\`\`\`
+
+Why: Express 5 stores mount paths only as compiled matcher closures; the original path string is unrecoverable after `Router.use(...)` returns. We patch `Router.prototype.use` and `.route` (auto-installed when this package is imported) to capture mount paths at registration time. The patch must be in place before any router is constructed.
+
+If your build sometimes constructs routers in modules imported before `express-route-parser`, set `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` and call `instrumentExpress5Router()` manually at the right time.
+
+### Express 5 path-syntax notes
+
+Express 5 uses `path-to-regexp@8`, which has different syntax than Express 4:
+
+| Express 4 | Express 5 |
+|---|---|
+| `/users/:id` | `/users/:id` (unchanged) |
+| `/users/:id?` | `/users{/:id}` |
+| `/files/*` | `/files/*splat` (named wildcard) |
+
+Migration is the consumer's job — Express 5 throws at registration time on the old syntax.
+
+### Extra parameter info on Express 5
+
+For routes parsed from an Express 5 app, each `Parameter` has a `type` field:
+
+\`\`\`typescript
+interface Parameter {
+  name: string;
+  in: 'path';
+  required: boolean;
+  type?: 'param' | 'wildcard';   // present on v5 routes
+}
+\`\`\`
+
+Express 4 routes don't populate `type` (the field is absent).
+```
+
+**File**: `CHANGELOG.md` (under `[Unreleased]`)
+
+```markdown
+## [Unreleased]
+
+### Added
+- **Express 5 support.** `parseExpressApp(app)` auto-detects Express 4 vs Express 5 and dispatches to the appropriate parser. New `Parameter.type` field surfaces path-to-regexp v8's `'param'` vs `'wildcard'` distinction for v5 routes.
+- Auto-installed `Router.prototype` patch on package import captures mount paths for Express 5 (necessary because Express 5 discards the path string at Layer construction). Idempotent; no-op on Express 4-only deployments. Disable via `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1`.
+- New export: `instrumentExpress5Router()` for users who need to defer instrumentation.
+
+### Changed
+- **BREAKING (peer dep widening): `peerDependencies.express` is now `^4.x || ^5.x`** (was `^4.x`). Existing v1.x consumers on Express 4 are unaffected; Express 5 consumers can now install. Same widening for `@types/express`.
+- Internal restructure: parser body split into `src/express-parser/v4.ts`, `src/express-parser/v5.ts`, and a thin dispatcher in `src/express-parser/index.ts`. Public API surface unchanged.
+
+### Fixed
+- (none specific to this release)
+```
+
+**Acceptance Criteria**:
+
+- [ ] README has the Express 5 section explaining import order and path-syntax migration.
+- [ ] CHANGELOG `[Unreleased]` entries cover Added (Express 5 + instrument), Changed (peer dep widening + restructure).
+
+---
+
+## Implementation Order
+
+Strict dependency order:
+
+1. **Unit 1** — `src/types/index.ts`. Foundational; no other unit compiles without `Parameter.type`.
+2. **Unit 2** — `src/express-parser/instrument.ts`. Independent; can be implemented standalone with its own tests.
+3. **Unit 3** — `src/express-parser/detect.ts`. Independent; small.
+4. **Unit 4** — Move `src/express-parser/index.ts` → `src/express-parser/v4.ts`. Mechanical move; verify no regression in existing tests.
+5. **Unit 5** — `src/express-parser/v5.ts`. Depends on Unit 1 (`Parameter.type`), Unit 2 (`ORIGINAL_PATH` symbol). Most complex unit.
+6. **Unit 6** — `src/express-parser/index.ts` (rewritten as dispatcher). Depends on Units 3, 4, 5.
+7. **Unit 7** — `src/index.ts` adds `import './express-parser/instrument'`. Trivial.
+8. **Unit 8** — `package.json` updates. Land before tests so npm install brings in `express-v5`.
+9. **Unit 9** — `src/__tests__/parser-v5.test.ts`. Depends on everything above.
+10. **Unit 10** — Extend `src/__tests__/types.test-d.ts`. Independent of the parser code path; can be done in parallel with Unit 9.
+11. **Unit 11** — README + CHANGELOG. Last.
+
+Two-agent parallel split is feasible:
+- **Agent A**: Units 1–7 (parser code path).
+- **Agent B**: Unit 8 + Unit 9 + Unit 10 (test infra + tests + type tests).
+
+Agent B has to wait for Agent A to finish for tests to compile, but can start on `package.json` updates + scaffolding immediately. For a single-agent run, follow the strict order.
+
+## Testing
+
+### Unit Tests
+
+| File | Status | Covers |
+|---|---|---|
+| `src/__tests__/parser.test.ts` | unchanged | All v4 behavior (117 existing tests stay green) |
+| `src/__tests__/parser-v5.test.ts` | **new** | All v5 behavior — coverage parity with v4 plus v5-specific (wildcard, optional segments, instrument-missing error) |
+| `src/__tests__/with-metadata.test.ts` | unchanged | (`withMetadata` works identically across versions) |
+| `src/__tests__/renderers.test.ts` | unchanged | (Renderers are version-agnostic) |
+| `src/__tests__/types.test-d.ts` | extended | New `Parameter.type` field |
+| `src/__tests__/example.test.ts` | unchanged | README round-trip smoke |
+
+### Cross-version coverage check
+
+After implementation, the v4 + v5 test files together should cover:
+- Every shape variant of `RouteMetaData` and `RouteMetaDataMulti`
+- All HTTP methods (GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS/all)
+- Mount path forms (string, regex, array)
+- Single + multi metadata middleware
+- Empty / routeless apps
+- Multi-method chains (issue #7)
+- `withMetadata` round-trip
+
+The v5 file mirrors the v4 file for shared scenarios; v5-specific scenarios (wildcard, optional segments, instrument-missing) live only in v5.
+
+### Coverage target
+
+Maintain ≥99% statements, ≥95% branches (current state).
+
+## Verification Checklist
+
+```bash
+# Units 1, 2, 3, 4, 5, 6, 7 — code compiles
+npm run build
+
+# Unit 8 — devDeps install
+npm install
+npm ls express express-v5 | grep -E 'express@4|express@5'  # both present
+
+# Unit 9 — tests pass
+npm test
+# Expected: 117 pre-existing tests + ~15 new v5 tests + 2 new type tests = ~134 total
+
+# Unit 10 — type tests
+npx vitest run src/__tests__/types.test-d.ts
+
+# Cross-version smoke
+node -e "
+require('./lib');                                            // auto-instrument fires
+const e4 = require('express'); const e5 = require('express-v5');
+const v4App = e4(); v4App.get('/v4', (_q,r)=>r.end());
+const v5App = e5(); v5App.get('/v5', (_q,r)=>r.end());
+const { parseExpressApp } = require('./lib');
+console.log('v4:', JSON.stringify(parseExpressApp(v4App)));
+console.log('v5:', JSON.stringify(parseExpressApp(v5App)));
+"
+
+# Lib/ structure
+test -f lib/express-parser/instrument.js
+test -f lib/express-parser/v4.js
+test -f lib/express-parser/v5.js
+test -f lib/express-parser/detect.js
+test -f lib/express-parser/index.js
+
+# Lint clean
+npm run lint
+```
+
+## Hardening Options (Not Implemented Now)
+
+- **Surface ancestor-router params on the leaf `RouteMetaData`** — current v5 parser only emits the leaf route's own params (e.g., `/api/:v/users/:id` → `pathParams: [{ name: 'id' }]`, missing `:v`). The v4 parser carries ancestors. Worth fixing for parity in a follow-up.
+- **Parse path-to-regexp v8 keys structurally** instead of regex-detecting `{...}` for optionality. If/when v8 exposes a richer parse API, swap.
+- **Provide a public `instrumentExpress5Router()` re-export** if power users ask for it. Currently only available via deep import.
+- **Tests for `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` path** via spawned subprocess. Skipped in v1 because of in-process module-cache reuse complexity.
+- **TypeScript discriminated union** between `Parameter` (v4) and `Parameter5` (v5) — currently a single shape with optional `type`. Discriminated form would be more rigorous; less DX-friendly.
+- **Expose `instrument`'s patched-marker symbol** for testing tools that want to verify their setup.
+- **Compatibility for path-to-regexp v6/v7** (Express 4.21+ may use these in minor variations) — currently we only test against v0.x (Express 4.18) and v8 (Express 5.2).
+- **Renderer support for `Parameter.type`** — render wildcard/optional differently in HTML/Markdown. Probably worth doing as a follow-up minor.
+
+## References
+
+- PoC research: `/tmp/erp-express5-research/poc.js` and `inspect*.js` (live during this design session; can be re-created from the design rationale)
+- Express 5 release notes: https://expressjs.com/en/guide/migrating-5.html
+- `router@2.x` source (the relevant Layer constructor): https://github.com/pillarjs/router/blob/master/lib/layer.js
+- `path-to-regexp@8` docs: https://github.com/pillarjs/path-to-regexp
+- Existing v4 parser: `src/express-parser/index.ts` (post 1.1.0)

--- a/docs/design/express-5-test-suite.md
+++ b/docs/design/express-5-test-suite.md
@@ -1,0 +1,358 @@
+# E2E Test Suite Design — Express 5 Surface
+
+Designed via the e2e-test-design skill, 2026-05-03. Companion to
+`docs/design/express-5-support.md` (the original v5 implementation design).
+
+## Project Summary
+
+`express-route-parser` is a TypeScript library exposing a single function,
+`parseExpressApp(app)`, that walks an Express app's router tree and returns
+a list of routes (`RouteMetaData[]`). Auto-detects Express 4 vs Express 5.
+
+**Public surface relevant to v5:**
+- `parseExpressApp(app, options?)` — the parser entry point
+- `instrumentExpress5Router()` — manual instrument, for advanced users
+- `withMetadata<M>(metadata)` — typed metadata wrapper
+- `renderRoutesAsHtml`, `renderRoutesAsMarkdown`, `renderRoutesAsJson`
+- `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` env var
+- Auto-installed `Router.prototype.use` / `.route` patch (side effect of import)
+
+## Test Environment
+
+- **Framework:** Vitest 4.x with v8 coverage; globals enabled (`describe`/`it`/`expect`).
+- **Express versions:** v4 via `express`, v5 via `express-v5` npm alias (`npm:express@^5.2.0`).
+- **Sub-process tests:** require a build (`npm run build`) so the fixture can `require('../../../lib')`. Existing `no-auto-instrument.test.ts` already enforces this via `beforeAll`.
+- **HTTP smoke:** native Node `fetch` (Node ≥ 20, matches our engines floor); `server.listen(0)` for a random port; `server.close()` in `afterAll`.
+- **Fixture conventions:** `.cjs` files under `src/__tests__/fixtures/` are excluded from eslint and tsconfig (`fixtures/**` ignore).
+
+## Existing Coverage (Baseline)
+
+| File | Tests | What it covers |
+|---|---:|---|
+| `parser-v5.test.ts` | 21 | Parser parity with v4 + v5-specific (wildcards, optional groups, ancestor params, regex/array mounts) |
+| `no-auto-instrument.test.ts` | 2 | Env-var escape hatch (negative + manual instrument) |
+| `types.test-d.ts` | 2 (v5 portion) | `Parameter['type']` union pinned |
+| `parser.test.ts` | many | All v4 behavior |
+| `renderers.test.ts` | many | Renderers via **synthetic** fixtures only |
+| `example.test.ts` | 1 | README v4 example round-trip |
+| `with-metadata.test.ts` | many | `withMetadata` |
+
+**Identified gaps in the v5 surface (drives the new tests below):**
+
+1. README v5 snippet not test-pinned
+2. Renderers never receive real v5-parsed routes — `type: 'wildcard'` is invisible to assertions
+3. No cross-version test (v4 + v5 in the same process)
+4. No idempotency test for `instrumentExpress5Router()`
+5. No coverage of `router.use(handler)` / bare-middleware / 4-arg error middleware on v5
+6. No coverage of `router.param()` on v5 (covered for v4)
+7. PUT / PATCH / DELETE round-trip on v5 not asserted
+8. No live HTTP smoke (parser correctness vs. Express's actual routing)
+9. Broken import order (sub-router constructed before our lib loads, no env var) is the most realistic user failure mode and isn't tested
+10. Big chained `.route()` (`.all().get().post().put().patch().delete()`) on v5 not asserted
+
+---
+
+## Golden-Path Tests
+
+### Journey: Documentation example fidelity
+
+**Priority:** high
+
+#### Test G1: README v5 example round-trips through the parser
+
+- **File:** `src/__tests__/example-v5.test.ts` (new — parallels existing `example.test.ts`)
+- **Setup:** Build the v5 app described verbatim in `README.md` lines 159-170, using `express-v5` and `withMetadata` for the metadata middleware.
+- **Steps:**
+  1. Construct an Express 5 app with one top-level route, one nested router with a sub-router, and a metadata-bearing route in the sub-router (mirror the v4 `example.test.ts`).
+  2. Call `parseExpressApp(app)`.
+- **Assertions:**
+  - Returned array matches the documented shape (path, method, pathParams with ancestor accumulation, metadata).
+  - Each `Parameter` on a v5 route has `type: 'param'` (or `'wildcard'`).
+- **Teardown:** none.
+
+---
+
+### Journey: Renderer integration with v5-parsed routes
+
+**Priority:** high
+
+#### Test G2: v5-parsed routes round-trip through HTML / Markdown / JSON renderers
+
+- **File:** `src/__tests__/renderers-v5.test.ts` (new — focused on integration, not unit-level renderer behavior)
+- **Setup:** Build a small v5 app with a deliberately diverse mix:
+  - a required-param route (`/users/:id`)
+  - an optional-segment route (`/users{/:id}`)
+  - a wildcard route (`/files/*splat`)
+  - a nested mount with an ancestor param (`/api/:tenant` → `/x`)
+  - a multi-method route (`.route('/y').get().post()`)
+- **Steps:**
+  1. Call `parseExpressApp(app)`.
+  2. Pass the result to `renderRoutesAsHtml`, `renderRoutesAsMarkdown`, `renderRoutesAsJson`.
+- **Assertions:**
+  - All three renderers return non-empty strings without throwing on `type: 'wildcard'`.
+  - HTML output contains all parsed paths as substrings.
+  - Markdown output contains all parsed paths and methods.
+  - JSON output is valid JSON whose parse equals the original parser result.
+  - Same flow with `multipleMetadata: true` produces valid output.
+- **Teardown:** none.
+
+---
+
+### Journey: All HTTP methods on v5
+
+**Priority:** medium
+
+#### Test G3: PUT, PATCH, DELETE round-trip
+
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** Register one route per method using `app.put`, `app.patch`, `app.delete`.
+- **Steps:** Call `parseExpressApp`.
+- **Assertions:** Each method appears in the output with the expected path. (GET / HEAD / OPTIONS / POST already covered.)
+- **Teardown:** none.
+
+---
+
+### Journey: Big chained `.route()` on v5
+
+**Priority:** medium
+
+#### Test G4: `.route('/x').all().get().post().put().patch().delete().head().options()`
+
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** Build a `Router.route('/multi')` chain with all standard methods plus `.all()`.
+- **Steps:** Call `parseExpressApp`.
+- **Assertions:**
+  - Output contains exactly one entry per explicit method (no `.all()` entry — its `method` is undefined).
+  - All entries share `path: '/multi'`.
+- **Teardown:** none.
+
+---
+
+### Journey: Cross-version (Express 4 + Express 5 parsed in the same process)
+
+**Priority:** high
+
+#### Test G5: parse v4 app, then parse v5 app, in the same test
+
+- **File:** `src/__tests__/cross-version.test.ts` (new)
+- **Setup:** Build a v4 app (`import express from 'express'`) with one route, and a v5 app (`import express5 from 'express-v5'`) with one route.
+- **Steps:**
+  1. Parse the v4 app.
+  2. Parse the v5 app.
+- **Assertions:**
+  - Both produce the correct paths and methods.
+  - The v4 entry's `pathParams[0]` does **not** have a `type` field (`expect(...).toBeUndefined()` on `type`).
+  - The v5 entry's `pathParams[0]` **does** have `type: 'param'`.
+  - Repeating the v4 parse after the v5 parse still works (no cross-contamination of state).
+- **Teardown:** none.
+
+---
+
+### Journey: Live HTTP smoke — parsed paths actually route on a running v5 server
+
+**Priority:** high
+
+#### Test G6: boot v5 server, parse, fetch each parsed path, expect 2xx
+
+- **File:** `src/__tests__/http-smoke-v5.test.ts` (new)
+- **Setup:**
+  - Build a v5 app with: a static route, a `:id` route, a wildcard route, a nested router with an ancestor `:tenant` param, and a multi-method `.route()` chain.
+  - Each handler responds with status 204 (no body).
+  - Start the server on port 0 in `beforeAll`; capture the assigned port; close in `afterAll`.
+- **Steps:**
+  1. `parseExpressApp(app)`.
+  2. For each parsed route, build a concrete URL by substituting realistic values for path params (e.g., `:id` → `42`, `*splat` → `a/b/c`, `{:opt}` → omit the segment).
+  3. `fetch(url, { method })` using the route's method (skip wildcard placeholders for `HEAD`/`OPTIONS` if those aren't registered).
+- **Assertions:**
+  - Every parsed route's substituted URL responds with a 2xx status. A 404 means the parser produced a path Express doesn't actually serve at — bug.
+- **Teardown:** `server.close()` in `afterAll`.
+
+**Note:** This test catches the "parser thinks the path is X but Express routes a different path" class of bug — the most valuable smoke for v5 since the path-string capture goes through a monkey-patch.
+
+---
+
+### Journey: `instrumentExpress5Router()` is idempotent
+
+**Priority:** medium
+
+#### Test G7: calling `instrumentExpress5Router()` repeatedly never throws and always returns true
+
+- **File:** `src/__tests__/parser-v5.test.ts` (extend) **or** `src/__tests__/instrument-idempotency.test.ts` (new)
+- **Setup:** Import `instrumentExpress5Router` from the lib.
+- **Steps:**
+  1. Call `instrumentExpress5Router()` three times in a row.
+  2. Construct a new v5 router and parse it.
+- **Assertions:**
+  - All three calls return `true`.
+  - The post-call parse still produces correct output (proving the patch wasn't broken by repeated calls).
+- **Teardown:** none.
+
+---
+
+### Journey: Sub-router defined in a separate module file (working case)
+
+**Priority:** medium
+
+#### Test G8: import order is enforced — lib first, then user module that constructs routers
+
+- **File:** sub-process test in `src/__tests__/import-order.test.ts` (new)
+- **Fixture:** `src/__tests__/fixtures/v5-routes-module.cjs` — a CommonJS module that requires `express-v5` and exports a sub-router.
+- **Fixture:** `src/__tests__/fixtures/import-order-good.cjs` — an entry-point fixture that requires our lib (which loads the patch), THEN requires the user-routes module, mounts it, and parses.
+- **Setup:** `beforeAll` runs `npm run build` (same pattern as `no-auto-instrument.test.ts`).
+- **Steps:** Spawn `node fixtures/import-order-good.cjs`, capture stdout.
+- **Assertions:** stdout matches `OK: <expected paths joined>` — proves the recommended import order works across module boundaries.
+- **Teardown:** none.
+
+---
+
+## Adversarial / Failure-Mode Tests
+
+### Category: User Mistakes — Wrong import order
+
+#### Test A1: sub-router constructed in a module loaded BEFORE our lib (no env var)
+
+- **Scenario:** A user's `app.js` imports their routes module (which requires `express-v5` and constructs a router) BEFORE importing `express-route-parser`. The patch installs late; the existing router's layers have no captured mount paths.
+- **File:** `src/__tests__/import-order.test.ts` (extend)
+- **Fixture:** `src/__tests__/fixtures/import-order-bad.cjs` — requires `express-v5` and constructs a sub-router with `app.use('/api/:tenant', subrouter)` BEFORE requiring our lib. Then requires our lib and calls `parseExpressApp`.
+- **Action:** Spawn `node fixtures/import-order-bad.cjs`.
+- **Expected behavior:** stdout matches `THREW: ` followed by the actionable message containing `sub-router was constructed before instrumentation`.
+- **Verify no side effects:** Process exits cleanly; no other crashes.
+
+**Note:** This is distinct from the existing `no-auto-instrument.test.ts` test — that one uses the env-var to skip the patch. This one tests the more realistic real-world failure mode: import order, no env var.
+
+---
+
+### Category: User Mistakes — Non-route layers in the router stack
+
+#### Test A2: 4-arg error middleware in a v5 router stack
+
+- **Scenario:** App has both a real route and a 4-arg error middleware (`(err, req, res, next) => ...`). The parser must skip the error middleware silently — it isn't a route.
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** `app.get('/x', ok); app.use((_err, _req, _res, next) => next());`
+- **Action:** `parseExpressApp(app)`.
+- **Expected behavior:** Output contains exactly one entry — the `/x` route. No error, no warning.
+- **Verify no side effects:** No console output, no thrown errors.
+
+#### Test A3: 404 catchall (bare middleware) at the end of the stack
+
+- **Scenario:** App has a real route followed by a 3-arg fallthrough handler used as a 404 catchall.
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** `app.get('/x', ok); app.use((_req, res) => res.status(404).send());`
+- **Action:** `parseExpressApp(app)`.
+- **Expected behavior:** Output contains exactly the `/x` route. The bare middleware is silently skipped.
+
+#### Test A4: bare middleware before route registration
+
+- **Scenario:** App calls `app.use(mw1); app.use(mw2); app.get('/x', h);` — common shape for body parsers, CORS, etc.
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** Two `app.use(fn)` calls with no path, then a real route.
+- **Action:** `parseExpressApp(app)`.
+- **Expected behavior:** Output is exactly `[{ path: '/x', method: 'get', pathParams: [] }]`.
+
+---
+
+### Category: User Mistakes — Param handlers and same-prefix mounts
+
+#### Test A5: `router.param()` handler is not a route on v5
+
+- **Scenario:** A v5 router uses `.param('id', handler)` to install a param resolver, plus a real route at `/users/:id`. The parser must surface only the route.
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** `router.param('id', handler); router.get('/users/:id', ok); app.use('/', router);`
+- **Action:** `parseExpressApp(app)`.
+- **Expected behavior:** Output is exactly the `/users/:id` GET entry; no entry for the param handler.
+
+#### Test A6: two sub-routers mounted at the same prefix
+
+- **Scenario:** `app.use('/api', r1); app.use('/api', r2);` — uncommon but legal. Both routers should be walked and their routes should appear in output with `/api` prefixed.
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** Two distinct routers each with one route, both mounted at `/api`.
+- **Action:** `parseExpressApp(app)`.
+- **Expected behavior:** Output contains both routes, each with the `/api` prefix.
+
+---
+
+### Category: Boundary Conditions
+
+#### Test A7: routerless v5 app
+
+- **Scenario:** An Express 5 app with no routes registered.
+- **File:** `src/__tests__/parser-v5.test.ts` (already present — keep)
+- **Action:** `parseExpressApp(app)`.
+- **Expected behavior:** Returns `[]`.
+
+*(Already covered; keep on the list as a checklist item.)*
+
+#### Test A8: chained `.all()` interleaved with explicit methods on v5
+
+- **Scenario:** `.route('/multi').all(handler).get(ok).post(ok)` — `.all()` produces a stack entry with no method; the parser must skip those.
+- **File:** `src/__tests__/parser-v5.test.ts` (extend)
+- **Setup:** `app.route('/multi').all(noopMw).get(ok).post(ok);`
+- **Action:** `parseExpressApp(app)`.
+- **Expected behavior:** Output contains exactly two entries — `get` and `post` at `/multi`.
+
+#### Test A9: route with no path arg via `app.use(fn)` — already covered
+
+*Equivalent to A4; deduped here.*
+
+---
+
+## Implementation Notes
+
+**Test files to add:**
+- `src/__tests__/example-v5.test.ts` — G1
+- `src/__tests__/renderers-v5.test.ts` — G2
+- `src/__tests__/cross-version.test.ts` — G5
+- `src/__tests__/http-smoke-v5.test.ts` — G6
+- `src/__tests__/import-order.test.ts` — G8 + A1
+- `src/__tests__/fixtures/v5-routes-module.cjs` — shared fixture
+- `src/__tests__/fixtures/import-order-good.cjs` — G8 fixture
+- `src/__tests__/fixtures/import-order-bad.cjs` — A1 fixture
+
+**Test files to extend:**
+- `src/__tests__/parser-v5.test.ts` — G3, G4, G7, A2, A3, A4, A5, A6, A8
+
+**Shared infrastructure:**
+- HTTP smoke uses native `fetch` (Node ≥ 20, no new dep).
+- Sub-process tests reuse the `beforeAll` build pattern from `no-auto-instrument.test.ts`.
+- Fixture `.cjs` files are already excluded from eslint and tsconfig.
+
+**Conventions to follow:**
+- Arrow functions everywhere, single quotes, no docstrings on tests, vitest globals.
+- Each test self-contained — no shared mutable state across tests.
+- HTTP smoke must close its server in `afterAll` to avoid hanging the runner.
+
+## Priority Order
+
+Implement in this order — highest-value first, lowest-risk first within each tier:
+
+**Tier 1 — High value, low risk (start here)**
+1. G3 — PUT/PATCH/DELETE methods (~3 lines per test)
+2. G4 — multi-method `.route()` chain
+3. A2, A3, A4, A5, A6, A8 — non-route layer skipping (extend `parser-v5.test.ts`, all small)
+4. G7 — idempotency
+
+**Tier 2 — High value, moderate risk**
+5. G1 — README v5 example pin
+6. G2 — renderer integration
+7. G5 — cross-version
+
+**Tier 3 — Highest value, highest setup cost**
+8. G8 + A1 — import-order sub-process tests (requires fixtures)
+9. G6 — live HTTP smoke (requires server lifecycle)
+
+Tier 1 should produce ~10 new green tests in one sitting. Tier 2 adds 3 files but uses existing infrastructure. Tier 3 is the biggest payoff — it's where real-world failure modes get caught — and should not be skipped despite the heavier setup.
+
+## Coverage targets
+
+- After Tier 1: ~150 total tests (was 142). All extensions land in `parser-v5.test.ts`.
+- After Tier 2: ~155 total tests across 9 files.
+- After Tier 3: ~160 total tests across 11 files (counting fixtures separately).
+- Statement coverage stays ≥ 99%; branch coverage stays ≥ 95% (current floor).
+
+## Out of scope
+
+- Express 4 surface — not the focus. Existing `parser.test.ts` is comprehensive.
+- Performance / load testing — this is a parsing library; runtime performance isn't a contract.
+- Visual regression on renderer output — the renderers are tested for content, not exact whitespace/style.
+- TypeScript strict-mode compatibility tests beyond what `types.test-d.ts` already pins.
+- Bundling / ESM compatibility — separate concern, not v5-specific.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,10 @@ import prettierConfig from 'eslint-config-prettier';
 export default tseslint.config(
   // Ignore patterns (replaces .eslintignore)
   {
-    ignores: ['lib/**', 'coverage/**', 'node_modules/**'],
+    // .cjs fixtures live under src/__tests__/fixtures/ and are loaded by
+    // sub-process tests against the compiled lib. They aren't TypeScript and
+    // aren't covered by tsconfig, so the type-checked linter chokes on them.
+    ignores: ['lib/**', 'coverage/**', 'node_modules/**', 'src/**/fixtures/**'],
   },
 
   // Base recommended configs
@@ -33,6 +36,9 @@ export default tseslint.config(
           // guard enforced by typescript-eslint. Tests live directly in src/__tests/,
           // not nested deeper, so a shallow pattern is exact and fast.
           allowDefaultProject: ['src/__tests__/*.ts'],
+          // The default cap is 8; we now have more test files than that. Raise
+          // the limit to accommodate the full suite without disabling the guard.
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 20,
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@types/express": "^4.17.13",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.3.0",
@@ -17,6 +18,8 @@
         "eslint-plugin-jsdoc": "^62.9.0",
         "eslint-plugin-prefer-arrow-functions": "^3.9.1",
         "express": "^4.18.1",
+        "express-v5": "npm:express@^5.2.0",
+        "path-to-regexp": "^8.0.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.1",
@@ -30,8 +33,8 @@
         "url": "https://www.buymeacoffee.com/nklisch"
       },
       "peerDependencies": {
-        "@types/express": "^4.x",
-        "express": "^4.x"
+        "@types/express": "^4.x || ^5.x",
+        "express": "^4.x || ^5.x"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -828,18 +831,45 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/express-v5": {
+      "name": "@types/express",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-v5/node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
@@ -863,13 +893,24 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
-    "node_modules/@types/serve-static": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
         "@types/node": "*"
       }
     },
@@ -1387,14 +1428,32 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
+    "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1433,10 +1492,11 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1525,6 +1585,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1540,12 +1615,45 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
@@ -1962,6 +2070,368 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-v5": {
+      "name": "express",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v5/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v5/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/express-v5/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-v5/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-v5/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-v5/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/express-v5/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v5/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v5/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express-v5/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/express-v5/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-v5/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1976,6 +2446,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
+    },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2098,23 +2575,52 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2129,16 +2635,17 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-flag": {
@@ -2151,15 +2658,29 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-entities": {
@@ -2266,6 +2787,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2665,6 +3193,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2771,10 +3309,14 @@
       "license": "MIT"
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2800,6 +3342,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -2880,10 +3432,15 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "dev": true
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3063,6 +3620,23 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3184,14 +3758,76 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3951,6 +4587,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4468,16 +5111,41 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/express-v5": {
+      "version": "npm:@types/express@5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      },
+      "dependencies": {
+        "@types/express-serve-static-core": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+          "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*",
+            "@types/send": "*"
+          }
+        }
+      }
+    },
+    "@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
-    "@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
     "@types/node": {
@@ -4501,13 +5169,22 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
-    "@types/serve-static": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+    "@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "dev": true,
       "requires": {
-        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "requires": {
+        "@types/http-errors": "*",
         "@types/node": "*"
       }
     },
@@ -4846,14 +5523,24 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true
     },
-    "call-bind": {
+    "call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "chai": {
@@ -4878,9 +5565,9 @@
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true
     },
     "cookie": {
@@ -4939,6 +5626,17 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4951,11 +5649,32 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
     "es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -5249,6 +5968,245 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+          "dev": true
+        }
+      }
+    },
+    "express-v5": {
+      "version": "npm:express@5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "requires": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+          "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+          "dev": true,
+          "requires": {
+            "mime-types": "^3.0.0",
+            "negotiator": "^1.0.0"
+          }
+        },
+        "body-parser": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+          "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+          "dev": true,
+          "requires": {
+            "bytes": "^3.1.2",
+            "content-type": "^1.0.5",
+            "debug": "^4.4.3",
+            "http-errors": "^2.0.0",
+            "iconv-lite": "^0.7.0",
+            "on-finished": "^2.4.1",
+            "qs": "^6.14.1",
+            "raw-body": "^3.0.1",
+            "type-is": "^2.0.1"
+          }
+        },
+        "content-disposition": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+          "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+          "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+          "dev": true
+        },
+        "cookie-signature": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+          "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+          "dev": true
+        },
+        "encodeurl": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+          "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+          "dev": true
+        },
+        "finalhandler": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+          "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.4.0",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "on-finished": "^2.4.1",
+            "parseurl": "^1.3.3",
+            "statuses": "^2.0.1"
+          }
+        },
+        "fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+          "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+          "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+          "dev": true,
+          "requires": {
+            "depd": "~2.0.0",
+            "inherits": "~2.0.4",
+            "setprototypeof": "~1.2.0",
+            "statuses": "~2.0.2",
+            "toidentifier": "~1.0.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+          "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "media-typer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+          "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+          "dev": true
+        },
+        "merge-descriptors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+          "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+          "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+          "dev": true,
+          "requires": {
+            "mime-db": "^1.54.0"
+          }
+        },
+        "negotiator": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+          "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.15.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+          "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.1.0"
+          }
+        },
+        "raw-body": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+          "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+          "dev": true,
+          "requires": {
+            "bytes": "~3.1.2",
+            "http-errors": "~2.0.1",
+            "iconv-lite": "~0.7.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "send": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+          "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.4.3",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "etag": "^1.8.1",
+            "fresh": "^2.0.0",
+            "http-errors": "^2.0.1",
+            "mime-types": "^3.0.2",
+            "ms": "^2.1.3",
+            "on-finished": "^2.4.1",
+            "range-parser": "^1.2.1",
+            "statuses": "^2.0.2"
+          }
+        },
+        "serve-static": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+          "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+          "dev": true,
+          "requires": {
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "parseurl": "^1.3.3",
+            "send": "^1.2.0"
+          }
+        },
+        "statuses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+          "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+          "dev": true
+        },
+        "type-is": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+          "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+          "dev": true,
+          "requires": {
+            "content-type": "^1.0.5",
+            "media-typer": "^1.1.0",
+            "mime-types": "^3.0.0"
+          }
         }
       }
     },
@@ -5347,20 +6305,37 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -5372,14 +6347,11 @@
         "is-glob": "^4.0.3"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
     },
     "has-flag": {
       "version": "4.0.0",
@@ -5388,10 +6360,19 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true
+    },
+    "hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "html-entities": {
       "version": "2.6.0",
@@ -5465,6 +6446,12 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -5668,6 +6655,12 @@
         "semver": "^7.5.3"
       }
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -5738,9 +6731,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true
     },
     "obug": {
@@ -5756,6 +6749,15 @@
       "dev": true,
       "requires": {
         "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
       }
     },
     "optionator": {
@@ -5815,9 +6817,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true
     },
     "pathe": {
@@ -5929,6 +6931,19 @@
         "@rolldown/pluginutils": "1.0.0-rc.17"
       }
     },
+    "router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6021,14 +7036,51 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       }
     },
     "siginfo": {
@@ -6432,6 +7484,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "homepage": "https://github.com/nklisch/express-route-parser#readme",
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/express-v5": "npm:@types/express@^5.0.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.3.0",
@@ -59,14 +60,16 @@
     "eslint-plugin-jsdoc": "^62.9.0",
     "eslint-plugin-prefer-arrow-functions": "^3.9.1",
     "express": "^4.18.1",
+    "express-v5": "npm:express@^5.2.0",
+    "path-to-regexp": "^8.0.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.5"
   },
   "peerDependencies": {
-    "@types/express": "^4.x",
-    "express": "^4.x"
+    "@types/express": "^4.x || ^5.x",
+    "express": "^4.x || ^5.x"
   },
   "engines": {
     "node": ">=20"

--- a/src/__tests__/cross-version.test.ts
+++ b/src/__tests__/cross-version.test.ts
@@ -1,0 +1,67 @@
+// Cross-version test: parse a v4 app and a v5 app in the same process.
+// Asserts the key distinguishing characteristic: v4 Parameter lacks `type`;
+// v5 Parameter always has `type`.
+import { describe, it, expect } from 'vitest';
+import e4 from 'express';
+import e5 from 'express-v5';
+import type { RequestHandler as Handler4 } from 'express';
+import type { RequestHandler as Handler5 } from 'express-v5';
+import { parseExpressApp } from '../index';
+
+const ok4: Handler4 = (_req, res) => {
+  res.status(204).send();
+};
+
+const ok5: Handler5 = (_req, res) => {
+  res.status(204).send();
+};
+
+describe('cross-version parsing (v4 + v5 in the same process)', () => {
+  it('v4 Parameter does not have a type field; v5 Parameter always does', () => {
+    const app4 = e4();
+    app4.get('/v4/:id', ok4);
+    const [route4] = parseExpressApp(app4);
+    expect(route4.path).toBe('/v4/:id');
+    expect(route4.method).toBe('get');
+    expect(route4.pathParams[0].name).toBe('id');
+    expect(route4.pathParams[0].type).toBeUndefined();
+
+    const app5 = e5();
+    app5.get('/v5/:id', ok5);
+    const [route5] = parseExpressApp(app5);
+    expect(route5.path).toBe('/v5/:id');
+    expect(route5.method).toBe('get');
+    expect(route5.pathParams[0].name).toBe('id');
+    expect(route5.pathParams[0].type).toBe('param');
+  });
+
+  it('repeating a v4 parse after a v5 parse produces correct output (no cross-contamination)', () => {
+    // Parse v5 first
+    const app5 = e5();
+    app5.get('/check/:x', ok5);
+    const [r5] = parseExpressApp(app5);
+    expect(r5.pathParams[0].type).toBe('param');
+
+    // Now parse v4 again — must still work with no type field
+    const app4 = e4();
+    app4.get('/check/:x', ok4);
+    const [r4] = parseExpressApp(app4);
+    expect(r4.path).toBe('/check/:x');
+    expect(r4.pathParams[0].type).toBeUndefined();
+  });
+
+  it('v4 and v5 wildcards both parse correctly with correct type presence', () => {
+    // v5 wildcard — type: 'wildcard'
+    const app5 = e5();
+    app5.get('/files/*splat', ok5);
+    const [r5] = parseExpressApp(app5);
+    expect(r5.pathParams[0].type).toBe('wildcard');
+
+    // v4 has no wildcard type concept — path is just a param with no type
+    const app4 = e4();
+    app4.get('/files/:splat*', ok4);
+    const [r4] = parseExpressApp(app4);
+    // v4 extracts the param but leaves type undefined
+    expect(r4.pathParams[0].type).toBeUndefined();
+  });
+});

--- a/src/__tests__/example-v5.test.ts
+++ b/src/__tests__/example-v5.test.ts
@@ -1,0 +1,55 @@
+// Pins the v5 README example so documentation and behaviour stay in sync.
+// Mirrors example.test.ts but uses express-v5 and asserts the type field
+// that v5 always populates.
+import { describe, it, expect } from 'vitest';
+import express from 'express-v5';
+import type { RequestHandler } from 'express-v5';
+import { parseExpressApp, withMetadata } from '../index';
+
+describe('README v5 example', () => {
+  it('round-trips through the parser with correct paths, params, and metadata', () => {
+    const app = express();
+    const router = express.Router();
+    const subrouter = express.Router();
+
+    const ok: RequestHandler = (_req, res) => {
+      res.status(204).send();
+    };
+
+    // Top-level route with metadata (mirrors the v4 example shape)
+    app.get(
+      '/resources/users/:id',
+      withMetadata({ operationId: 'getUserById', notes: 'These are some notes' }),
+      ok,
+    );
+
+    // Nested sub-router with metadata on the leaf route
+    subrouter.get(
+      '/:resourceId',
+      withMetadata({ operationId: 'getResourceByEntity', hidden: true, schema: {} }),
+      ok,
+    );
+    router.use('/:entity', subrouter);
+    app.use('/dashboard', router);
+
+    const parsed = parseExpressApp(app);
+
+    expect(parsed).toEqual([
+      {
+        path: '/resources/users/:id',
+        method: 'get',
+        pathParams: [{ name: 'id', in: 'path', required: true, type: 'param' }],
+        metadata: { operationId: 'getUserById', notes: 'These are some notes' },
+      },
+      {
+        path: '/dashboard/:entity/:resourceId',
+        method: 'get',
+        pathParams: [
+          { name: 'entity', in: 'path', required: true, type: 'param' },
+          { name: 'resourceId', in: 'path', required: true, type: 'param' },
+        ],
+        metadata: { operationId: 'getResourceByEntity', hidden: true, schema: {} },
+      },
+    ]);
+  });
+});

--- a/src/__tests__/fixtures/import-order-bad.cjs
+++ b/src/__tests__/fixtures/import-order-bad.cjs
@@ -1,0 +1,34 @@
+// Fixture for the A1 (broken import order) test.
+// The user module is required FIRST, constructing a Router and mounting it
+// BEFORE the express-route-parser patch is installed. The lib is then
+// required LATE — the patch installs, but the mount layer was already
+// recorded without the [ORIGINAL_PATH] symbol, so parseExpressApp throws.
+//
+// This is distinct from no-auto-instrument.cjs — that fixture uses the
+// env var to disable the patch. This fixture tests the pure import-order
+// failure mode (no env var; the patch just installs too late).
+//
+// stdout contract:
+//   "THREW: <error.message>\n"  on the expected throw
+//   "NO_THROW\n"                if the library failed to detect the bad state
+
+'use strict';
+
+// 1. Load express-v5 and construct + mount the router BEFORE our lib loads.
+//    The patch hasn't run yet at this point, so app.use() doesn't capture
+//    the mount path with [ORIGINAL_PATH].
+const express = require('express-v5');
+const app = express();
+const { router } = require('./v5-routes-module.cjs');
+app.use('/api/:tenant', router);
+
+// 2. Require the lib LATE — patch installs now, but the layer above was
+//    already written to app's stack without [ORIGINAL_PATH].
+const { parseExpressApp } = require('../../../lib');
+
+try {
+  parseExpressApp(app);
+  process.stdout.write('NO_THROW\n');
+} catch (e) {
+  process.stdout.write('THREW: ' + e.message + '\n');
+}

--- a/src/__tests__/fixtures/import-order-good.cjs
+++ b/src/__tests__/fixtures/import-order-good.cjs
@@ -1,0 +1,29 @@
+// Fixture for the G8 (working import order) test.
+// The lib is required FIRST so the Router.prototype patch is in place,
+// then the user routes module is loaded (which constructs a Router),
+// then the app is created and the router is mounted.
+// This is the recommended pattern.
+//
+// stdout contract:
+//   "OK: <comma-joined paths>\n"  on success
+//   "THREW: <error.message>\n"    if something unexpected blew up
+
+'use strict';
+
+// 1. Require the lib first — this installs the Router.prototype patch
+const { parseExpressApp } = require('../../../lib');
+
+// 2. Now require the user module that constructs a Router (patch is active)
+const { router } = require('./v5-routes-module.cjs');
+
+// 3. Create the app and mount the router
+const express = require('express-v5');
+const app = express();
+app.use('/api/:tenant', router);
+
+try {
+  const routes = parseExpressApp(app);
+  process.stdout.write('OK: ' + routes.map((r) => r.path).join(',') + '\n');
+} catch (e) {
+  process.stdout.write('THREW: ' + e.message + '\n');
+}

--- a/src/__tests__/fixtures/manual-instrument.cjs
+++ b/src/__tests__/fixtures/manual-instrument.cjs
@@ -1,0 +1,31 @@
+// Fixture for the manual-instrumentation path. With the env var set the
+// auto-patch is skipped, but `instrumentExpress5Router()` must still work
+// when called BEFORE `express-v5` is required.
+//
+// stdout contract:
+//   "OK: <comma-joined paths>\n"  on success
+//   "THREW: <error.message>\n"    if the manual call didn't take effect
+
+'use strict';
+
+process.env.EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT = '1';
+
+// Require the lib first so the side-effect import runs (it should be a no-op
+// thanks to the env var), then call instrumentExpress5Router() explicitly
+// BEFORE requiring express-v5 / constructing any routers.
+const { instrumentExpress5Router, parseExpressApp } = require('../../../lib');
+instrumentExpress5Router();
+
+const express = require('express-v5');
+
+const app = express();
+const router = express.Router();
+router.get('/x', (_req, res) => res.send());
+app.use('/api/:tenant', router);
+
+try {
+  const routes = parseExpressApp(app);
+  process.stdout.write('OK: ' + routes.map((r) => r.path).join(',') + '\n');
+} catch (e) {
+  process.stdout.write('THREW: ' + e.message + '\n');
+}

--- a/src/__tests__/fixtures/no-auto-instrument.cjs
+++ b/src/__tests__/fixtures/no-auto-instrument.cjs
@@ -1,0 +1,27 @@
+// Fixture for the EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1 negative test.
+// Run as a Node sub-process with the env var set; the parser should throw
+// because the v5 sub-router was constructed without the patch in place.
+//
+// stdout contract:
+//   "THREW: <error.message>\n"  on the expected throw
+//   "NO_THROW\n"                if the auto-instrument escape hatch failed
+
+'use strict';
+
+// Defensive: belt-and-suspenders even though the sub-process inherits the env.
+process.env.EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT = '1';
+
+const express = require('express-v5');
+const { parseExpressApp } = require('../../../lib');
+
+const app = express();
+const router = express.Router();
+router.get('/x', (_req, res) => res.send());
+app.use('/api/:tenant', router);
+
+try {
+  parseExpressApp(app);
+  process.stdout.write('NO_THROW\n');
+} catch (e) {
+  process.stdout.write('THREW: ' + e.message + '\n');
+}

--- a/src/__tests__/fixtures/v5-routes-module.cjs
+++ b/src/__tests__/fixtures/v5-routes-module.cjs
@@ -1,0 +1,15 @@
+// Shared fixture: defines and exports a v5 sub-router.
+// Used by import-order-good.cjs and import-order-bad.cjs.
+// Important: this module requires express-v5 and constructs a Router,
+// so the order in which the calling fixture requires THIS module
+// relative to requiring express-route-parser determines whether the
+// patch is installed before or after Router construction.
+
+'use strict';
+
+const express = require('express-v5');
+
+const router = express.Router();
+router.get('/x', (_req, res) => res.send('ok'));
+
+module.exports = { router };

--- a/src/__tests__/http-smoke-v5.test.ts
+++ b/src/__tests__/http-smoke-v5.test.ts
@@ -1,0 +1,105 @@
+// G6 — Live HTTP smoke test for v5.
+//
+// Boots a real Express 5 server on a random port, parses it, then fetches
+// every parsed route with a concrete URL. A 404 means the parser produced
+// a path Express doesn't actually serve — that's a parser bug.
+//
+// Substitution rules for concrete URLs:
+// :name    → 'sample'
+// *splat   → 'a/b/c'  (wildcards require at least one segment in ptR v8)
+// {/:opt}  → omitted (optional segment — hit the absent form)
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express-v5';
+import type { RequestHandler } from 'express-v5';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { parseExpressApp } from '../index';
+import type { RouteMetaData, RouteMetaDataMulti } from '../types';
+
+const ok: RequestHandler = (_req, res) => {
+  res.status(204).send();
+};
+
+let server: Server;
+let baseUrl: string;
+let routes: RouteMetaData[] | RouteMetaDataMulti[];
+
+beforeAll(async () => {
+  const app = express();
+
+  app.get('/health', ok);
+  app.get('/users/:id', ok);
+  app.get('/files/*splat', ok);
+  app.post('/items', ok);
+
+  const router = express.Router();
+  router.get('/x', ok);
+  app.use('/api/:tenant', router);
+
+  app.route('/multi').get(ok).post(ok);
+
+  routes = parseExpressApp(app);
+
+  server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const port = (server.address() as AddressInfo).port;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+/**
+ * Substitute path parameters with concrete values so we can make real HTTP
+ * requests. Returns null for paths that cannot be automatically substituted
+ * (e.g., RegExp mounts).
+ */
+const concreteUrl = (path: RouteMetaData['path']): string | null => {
+  if (typeof path !== 'string') return null;
+  return (
+    path
+      // wildcard segment: *splat → a/b/c
+      .replace(/\*\w+/g, 'a/b/c')
+      // required param: :name → sample
+      .replace(/:(\w+)/g, 'sample')
+      // optional group: {/...} — drop the entire optional segment
+      .replace(/\{[^}]*\}/g, '')
+      // clean up any double slashes from dropped optional segments
+      .replace(/\/{2,}/g, '/')
+  );
+};
+
+describe('G6: HTTP smoke — every parsed route responds 2xx on its substituted URL', () => {
+  it('has at least one parsed route to smoke', () => {
+    expect(routes.length).toBeGreaterThan(0);
+  });
+
+  it('each parsed route responds with a 2xx status on its concrete URL', async () => {
+    for (const route of routes) {
+      const urlPath = concreteUrl(route.path);
+      if (urlPath === null) continue; // skip regex/array paths
+
+      const url = `${baseUrl}${urlPath}`;
+      const method = route.method.toUpperCase();
+
+      // HEAD and OPTIONS are auto-handled by Express; skip if not explicitly
+      // registered in this smoke app (avoid false negatives from auto-responses)
+      if (method === 'HEAD' || method === 'OPTIONS') continue;
+
+      const res = await fetch(url, { method });
+      expect(
+        res.status,
+        `Expected 2xx for ${method} ${urlPath} but got ${res.status}`,
+      ).toBeGreaterThanOrEqual(200);
+      expect(
+        res.status,
+        `Expected 2xx for ${method} ${urlPath} but got ${res.status}`,
+      ).toBeLessThan(300);
+    }
+  });
+});

--- a/src/__tests__/import-order.test.ts
+++ b/src/__tests__/import-order.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Sub-process tests for import-order correctness.
+ *
+ * G8 — lib loaded first, then user module: parse succeeds.
+ * A1 — user module loaded first (constructs a Router), then lib: parse throws.
+ *
+ * Why sub-process: Router.prototype is patched as a side-effect of importing
+ * the lib. Once patched, the patch is process-wide and persistent. The only
+ * way to test "what happens when a Router is constructed before the patch"
+ * is to spawn a fresh Node process where the patch hasn't run yet.
+ *
+ * The sub-process requires the COMPILED lib (lib/index.js). We always
+ * rebuild in beforeAll so a stale build cannot produce misleading results.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '../..');
+const LIB_ENTRY = path.join(ROOT, 'lib', 'index.js');
+const FIXTURE_DIR = path.join(__dirname, 'fixtures');
+
+describe('import order — v5 sub-router patch timing', () => {
+  beforeAll(() => {
+    execSync('npm run build', { cwd: ROOT, stdio: 'inherit' });
+    if (!existsSync(LIB_ENTRY)) {
+      throw new Error(`Build did not produce ${LIB_ENTRY}`);
+    }
+  }, 60_000);
+
+  it('G8: lib required before user-routes module — parse succeeds', () => {
+    const out = execFileSync(
+      process.execPath,
+      [path.join(FIXTURE_DIR, 'import-order-good.cjs')],
+      { encoding: 'utf8' },
+    );
+    expect(out.trim()).toBe('OK: /api/:tenant/x');
+  });
+
+  it('A1: user-routes module required before lib — parse throws actionable error', () => {
+    const out = execFileSync(
+      process.execPath,
+      [path.join(FIXTURE_DIR, 'import-order-bad.cjs')],
+      { encoding: 'utf8' },
+    );
+    expect(out).toMatch(/^THREW: /);
+    expect(out).toMatch(/sub-router was constructed before instrumentation/);
+  });
+});

--- a/src/__tests__/no-auto-instrument.test.ts
+++ b/src/__tests__/no-auto-instrument.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Sub-process tests for the `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1`
+ * escape hatch.
+ *
+ * Why a sub-process: the auto-instrument side effect runs at module load
+ * time inside `src/index.ts`. Any test that imports the lib has already
+ * triggered the patch, and the `Router.prototype` mutation is process-wide
+ * and persistent. The only honest way to verify the env-var escape hatch
+ * is to spawn a fresh Node process with the env var set.
+ *
+ * The sub-process imports the COMPILED lib (`lib/index.js`) — there's no
+ * TS runner installed for child processes (no tsx/ts-node/vite-node), so
+ * the test ensures `lib/` exists by running `npm run build` if necessary.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '../..');
+const LIB_ENTRY = path.join(ROOT, 'lib', 'index.js');
+const FIXTURE_DIR = path.join(__dirname, 'fixtures');
+
+describe('EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT escape hatch', () => {
+  beforeAll(() => {
+    // Always rebuild so the sub-process tests run against current source.
+    // `lib/` may be stale from a previous build with different source on disk;
+    // a stale lib silently produces a misleading test result.
+    execSync('npm run build', { cwd: ROOT, stdio: 'inherit' });
+    if (!existsSync(LIB_ENTRY)) {
+      throw new Error(`Build did not produce ${LIB_ENTRY}`);
+    }
+  }, 60_000);
+
+  it('skips the auto-patch; v5 sub-router parse throws the expected error', () => {
+    const out = execFileSync(
+      process.execPath,
+      [path.join(FIXTURE_DIR, 'no-auto-instrument.cjs')],
+      {
+        env: { ...process.env, EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT: '1' },
+        encoding: 'utf8',
+      },
+    );
+    expect(out).toMatch(/^THREW: /);
+    expect(out).toMatch(/sub-router was constructed before instrumentation/);
+  });
+
+  it('manual instrumentExpress5Router() before router construction restores parsing', () => {
+    const out = execFileSync(
+      process.execPath,
+      [path.join(FIXTURE_DIR, 'manual-instrument.cjs')],
+      {
+        env: { ...process.env, EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT: '1' },
+        encoding: 'utf8',
+      },
+    );
+    expect(out.trim()).toBe('OK: /api/:tenant/x');
+  });
+});

--- a/src/__tests__/parser-v5.test.ts
+++ b/src/__tests__/parser-v5.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import express from 'express-v5';
 import type { Express, RequestHandler } from 'express-v5';
-import { parseExpressApp, withMetadata } from '../index';
+import { parseExpressApp, withMetadata, instrumentExpress5Router } from '../index';
 
 describe('Express 5 parser', () => {
   let app: Express;
@@ -53,7 +53,7 @@ describe('Express 5 parser', () => {
     ]);
   });
 
-  it('parses nested sub-routers and joins mount paths', () => {
+  it('parses nested sub-routers, joins mount paths, accumulates ancestor params', () => {
     const router = express.Router();
     const sub = express.Router();
     sub.get('/inner/:thing', ok);
@@ -66,13 +66,77 @@ describe('Express 5 parser', () => {
         path: '/api/:version/sub/:tenant/inner/:thing',
         method: 'get',
         pathParams: [
+          { name: 'version', in: 'path', required: true, type: 'param' },
+          { name: 'tenant', in: 'path', required: true, type: 'param' },
           { name: 'thing', in: 'path', required: true, type: 'param' },
         ],
       },
     ]);
-    // Note: pathParams reflects the LEAF route's own params, not the
-    // ancestors' — matching existing v4 behavior. (This may be a separate
-    // gap to address later, but it preserves parity.)
+  });
+
+  it('regex mount path: leaf params only, no throw', () => {
+    const r = express.Router();
+    r.get('/users/:id', ok);
+    app.use(/^\/api/, r);
+    const [route] = parseExpressApp(app);
+    expect(route.method).toBe('get');
+    expect(route.pathParams).toEqual([
+      { name: 'id', in: 'path', required: true, type: 'param' },
+    ]);
+  });
+
+  it('array mount path: leaf params only, no throw', () => {
+    const r = express.Router();
+    r.get('/users/:id', ok);
+    app.use(['/v1', '/v2'], r);
+    const [route] = parseExpressApp(app);
+    expect(route.method).toBe('get');
+    expect(route.pathParams).toEqual([
+      { name: 'id', in: 'path', required: true, type: 'param' },
+    ]);
+  });
+
+  it('three-level nested mount: all ancestor params are reported', () => {
+    const router = express.Router();
+    const sub = express.Router();
+    sub.get('/c/:z', ok);
+    router.use('/b/:y', sub);
+    app.use('/a/:x', router);
+
+    const [route] = parseExpressApp(app);
+    expect(route.path).toBe('/a/:x/b/:y/c/:z');
+    expect(route.pathParams).toEqual([
+      { name: 'x', in: 'path', required: true, type: 'param' },
+      { name: 'y', in: 'path', required: true, type: 'param' },
+      { name: 'z', in: 'path', required: true, type: 'param' },
+    ]);
+  });
+
+  it('optional ancestor segment is reported with required: false', () => {
+    const r = express.Router();
+    r.get('/x', ok);
+    app.use('/api{/:v}', r);
+    const [route] = parseExpressApp(app);
+    expect(route.pathParams).toEqual([
+      { name: 'v', in: 'path', required: false, type: 'param' },
+    ]);
+  });
+
+  it('nested optional groups: inner param is structurally optional', () => {
+    app.get('/a/{:b{/:c}}', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.pathParams).toEqual([
+      { name: 'b', in: 'path', required: false, type: 'param' },
+      { name: 'c', in: 'path', required: false, type: 'param' },
+    ]);
+  });
+
+  it('wildcard inside a group is still reported as wildcard / not required', () => {
+    app.get('/{*splat}', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.pathParams).toEqual([
+      { name: 'splat', in: 'path', required: false, type: 'wildcard' },
+    ]);
   });
 
   it('parses Router#route().get().post() as separate entries (issue #7 parity)', () => {
@@ -134,5 +198,154 @@ describe('Express 5 parser', () => {
     app.get('/x', withMetadata({ op: 'getX' }), ok);
     const [route] = parseExpressApp(app);
     expect(route.metadata).toEqual({ op: 'getX' });
+  });
+
+  // --- G3: PUT / PATCH / DELETE round-trip --------------------------------
+
+  it('PUT round-trip', () => {
+    app.put('/items/:id', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.method).toBe('put');
+    expect(route.path).toBe('/items/:id');
+    expect(route.pathParams).toEqual([
+      { name: 'id', in: 'path', required: true, type: 'param' },
+    ]);
+  });
+
+  it('PATCH round-trip', () => {
+    app.patch('/items/:id', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.method).toBe('patch');
+    expect(route.path).toBe('/items/:id');
+  });
+
+  it('DELETE round-trip', () => {
+    app.delete('/items/:id', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.method).toBe('delete');
+    expect(route.path).toBe('/items/:id');
+  });
+
+  // --- G4: full chained .route() with all methods -------------------------
+
+  it('.route().all().get().post().put().patch().delete().head().options() — all explicit methods emitted, .all() skipped', () => {
+    app
+      .route('/multi')
+      .all(ok)
+      .get(ok)
+      .post(ok)
+      .put(ok)
+      .patch(ok)
+      .delete(ok)
+      .head(ok)
+      .options(ok);
+
+    const parsed = parseExpressApp(app);
+    const methods = parsed.map((r) => r.method);
+
+    // Every explicit method must appear
+    expect(methods).toContain('get');
+    expect(methods).toContain('post');
+    expect(methods).toContain('put');
+    expect(methods).toContain('patch');
+    expect(methods).toContain('delete');
+    expect(methods).toContain('head');
+    expect(methods).toContain('options');
+
+    // .all() must NOT produce a standalone entry (no method)
+    expect(methods.every((m) => m !== undefined && m !== '')).toBe(true);
+
+    // All share the same path
+    expect(parsed.every((r) => r.path === '/multi')).toBe(true);
+  });
+
+  // --- G7: instrumentExpress5Router() idempotency -------------------------
+
+  it('instrumentExpress5Router() called three times always returns true and parse still works', () => {
+    expect(instrumentExpress5Router()).toBe(true);
+    expect(instrumentExpress5Router()).toBe(true);
+    expect(instrumentExpress5Router()).toBe(true);
+
+    app.get('/health', ok);
+    expect(parseExpressApp(app)).toEqual([
+      { path: '/health', method: 'get', pathParams: [] },
+    ]);
+  });
+
+  // --- A2: 4-arg error middleware silently skipped ------------------------
+
+  it('4-arg error middleware in the stack is silently skipped', () => {
+    app.get('/x', ok);
+    // Must be exactly 4 args — Express detects error middleware by fn.length === 4
+    app.use((_err: unknown, _req: unknown, _res: unknown, next: () => void) => next());
+    const parsed = parseExpressApp(app);
+    expect(parsed).toEqual([{ path: '/x', method: 'get', pathParams: [] }]);
+  });
+
+  // --- A3: 3-arg catchall / 404 handler silently skipped -----------------
+
+  it('bare 3-arg fallthrough handler (404 catchall) is silently skipped', () => {
+    app.get('/x', ok);
+    app.use((_req: unknown, res: { status: (n: number) => { send: () => void } }) =>
+      res.status(404).send(),
+    );
+    const parsed = parseExpressApp(app);
+    expect(parsed).toEqual([{ path: '/x', method: 'get', pathParams: [] }]);
+  });
+
+  // --- A4: bare middleware before route registration ----------------------
+
+  it('bare app.use(fn) calls before a real route are silently skipped', () => {
+    const mw: RequestHandler = (_req, _res, next) => next();
+    app.use(mw);
+    app.use(mw);
+    app.get('/x', ok);
+    expect(parseExpressApp(app)).toEqual([{ path: '/x', method: 'get', pathParams: [] }]);
+  });
+
+  // --- A5: router.param() handler is not a route -------------------------
+
+  it('router.param() handler does not appear as a route', () => {
+    const router = express.Router();
+    router.param('id', (_req, _res, next) => next());
+    router.get('/users/:id', ok);
+    app.use('/', router);
+
+    const parsed = parseExpressApp(app);
+    expect(parsed).toEqual([
+      {
+        path: '/users/:id',
+        method: 'get',
+        pathParams: [{ name: 'id', in: 'path', required: true, type: 'param' }],
+      },
+    ]);
+  });
+
+  // --- A6: two sub-routers mounted at the same prefix --------------------
+
+  it('two sub-routers at the same prefix both have their routes emitted', () => {
+    const r1 = express.Router();
+    r1.get('/a', ok);
+    const r2 = express.Router();
+    r2.post('/b', ok);
+
+    app.use('/api', r1);
+    app.use('/api', r2);
+
+    const parsed = parseExpressApp(app);
+    expect(parsed).toContainEqual({ path: '/api/a', method: 'get', pathParams: [] });
+    expect(parsed).toContainEqual({ path: '/api/b', method: 'post', pathParams: [] });
+    expect(parsed).toHaveLength(2);
+  });
+
+  // --- A8: .route().all() interleaved with explicit methods ---------------
+
+  it('.route().all(mw).get(ok).post(ok) — .all() skipped, get+post emitted', () => {
+    app.route('/multi').all(ok).get(ok).post(ok);
+
+    const parsed = parseExpressApp(app);
+    expect(parsed).toHaveLength(2);
+    expect(parsed).toContainEqual({ path: '/multi', method: 'get', pathParams: [] });
+    expect(parsed).toContainEqual({ path: '/multi', method: 'post', pathParams: [] });
   });
 });

--- a/src/__tests__/parser-v5.test.ts
+++ b/src/__tests__/parser-v5.test.ts
@@ -1,0 +1,138 @@
+// Note: this file uses the `express-v5` npm alias (see package.json).
+// The package's auto-instrument side effect runs when we import from the lib.
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express-v5';
+import type { Express, RequestHandler } from 'express-v5';
+import { parseExpressApp, withMetadata } from '../index';
+
+describe('Express 5 parser', () => {
+  let app: Express;
+  const ok: RequestHandler = (_req, res) => {
+    res.status(204).send();
+  };
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  // --- Coverage parity with the v4 suite ------------------------------------
+
+  it('returns [] for an Express 5 app with no routes', () => {
+    expect(parseExpressApp(app)).toEqual([]);
+  });
+
+  it('parses a single top-level route', () => {
+    app.get('/health', ok);
+    expect(parseExpressApp(app)).toEqual([
+      { path: '/health', method: 'get', pathParams: [] },
+    ]);
+  });
+
+  it('extracts a required path parameter with type info', () => {
+    app.get('/users/:id', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.path).toBe('/users/:id');
+    expect(route.pathParams).toEqual([
+      { name: 'id', in: 'path', required: true, type: 'param' },
+    ]);
+  });
+
+  it('parses an optional segment using v5 syntax {:name}', () => {
+    app.get('/users{/:id}', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.pathParams[0].name).toBe('id');
+    expect(route.pathParams[0].required).toBe(false);
+    expect(route.pathParams[0].type).toBe('param');
+  });
+
+  it('parses a wildcard segment as type "wildcard"', () => {
+    app.get('/files/*splat', ok);
+    const [route] = parseExpressApp(app);
+    expect(route.pathParams).toEqual([
+      { name: 'splat', in: 'path', required: false, type: 'wildcard' },
+    ]);
+  });
+
+  it('parses nested sub-routers and joins mount paths', () => {
+    const router = express.Router();
+    const sub = express.Router();
+    sub.get('/inner/:thing', ok);
+    router.use('/sub/:tenant', sub);
+    app.use('/api/:version', router);
+
+    const parsed = parseExpressApp(app);
+    expect(parsed).toEqual([
+      {
+        path: '/api/:version/sub/:tenant/inner/:thing',
+        method: 'get',
+        pathParams: [
+          { name: 'thing', in: 'path', required: true, type: 'param' },
+        ],
+      },
+    ]);
+    // Note: pathParams reflects the LEAF route's own params, not the
+    // ancestors' — matching existing v4 behavior. (This may be a separate
+    // gap to address later, but it preserves parity.)
+  });
+
+  it('parses Router#route().get().post() as separate entries (issue #7 parity)', () => {
+    app.route('/users').get(ok).post(ok);
+    expect(parseExpressApp(app)).toEqual([
+      { path: '/users', method: 'get', pathParams: [] },
+      { path: '/users', method: 'post', pathParams: [] },
+    ]);
+  });
+
+  it('throws on multiple metadata middlewares in single mode', () => {
+    app.get('/x', withMetadata({ a: 1 }), withMetadata({ b: 2 }), ok);
+    expect(() => parseExpressApp(app)).toThrow(/multipleMetadata: true/);
+  });
+
+  it('returns metadata: any[] in multipleMetadata mode', () => {
+    app.get('/x', withMetadata({ a: 1 }), withMetadata({ b: 2 }), ok);
+    const [route] = parseExpressApp(app, { multipleMetadata: true });
+    expect(route.metadata).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('handles regex mount path', () => {
+    const r = express.Router();
+    r.get('/inner', ok);
+    app.use(/^\/api/, r);
+    expect(() => parseExpressApp(app)).not.toThrow();
+    const parsed = parseExpressApp(app);
+    expect(parsed.length).toBeGreaterThanOrEqual(1);
+    expect(parsed[0].method).toBe('get');
+  });
+
+  it('handles array mount path', () => {
+    const r = express.Router();
+    r.get('/inner', ok);
+    app.use(['/v1', '/v2'], r);
+    expect(() => parseExpressApp(app)).not.toThrow();
+    const parsed = parseExpressApp(app);
+    expect(parsed.length).toBeGreaterThanOrEqual(1);
+    expect(parsed[0].method).toBe('get');
+  });
+
+  it('HEAD method round-trip', () => {
+    app.head('/health', ok);
+    expect(parseExpressApp(app)[0].method).toBe('head');
+  });
+
+  it('OPTIONS method round-trip', () => {
+    app.options('/cors', ok);
+    expect(parseExpressApp(app)[0].method).toBe('options');
+  });
+
+  it('mounted empty router produces no entries', () => {
+    const empty = express.Router();
+    app.use('/empty', empty);
+    expect(parseExpressApp(app)).toEqual([]);
+  });
+
+  it('withMetadata round-trips through v5 parser', () => {
+    app.get('/x', withMetadata({ op: 'getX' }), ok);
+    const [route] = parseExpressApp(app);
+    expect(route.metadata).toEqual({ op: 'getX' });
+  });
+});

--- a/src/__tests__/renderers-v5.test.ts
+++ b/src/__tests__/renderers-v5.test.ts
@@ -1,0 +1,131 @@
+// Integration test: real v5-parsed routes fed into all three renderers.
+// Distinct from renderers.test.ts (which uses synthetic fixtures).
+// The goal is to ensure type:'wildcard' and other v5-specific shapes
+// don't break rendering and that parser output round-trips cleanly.
+import { describe, it, expect, beforeAll } from 'vitest';
+import express from 'express-v5';
+import type { RequestHandler } from 'express-v5';
+import { parseExpressApp } from '../index';
+import { renderRoutesAsHtml, renderRoutesAsMarkdown, renderRoutesAsJson } from '../renderers';
+import type { RouteMetaData, RouteMetaDataMulti } from '../types';
+
+const ok: RequestHandler = (_req, res) => {
+  res.status(204).send();
+};
+
+let routes: RouteMetaData[] | RouteMetaDataMulti[];
+let routesMulti: RouteMetaData[] | RouteMetaDataMulti[];
+
+beforeAll(() => {
+  const app = express();
+  const router = express.Router();
+
+  app.get('/users/:id', ok);
+  app.get('/users{/:id}', ok);
+  app.get('/files/*splat', ok);
+  router.get('/x', ok);
+  app.use('/api/:tenant', router);
+  app.route('/y').get(ok).post(ok);
+
+  routes = parseExpressApp(app);
+
+  const app2 = express();
+  const router2 = express.Router();
+
+  app2.get('/users/:id', ok);
+  app2.get('/users{/:id}', ok);
+  app2.get('/files/*splat', ok);
+  router2.get('/x', ok);
+  app2.use('/api/:tenant', router2);
+  app2.route('/y').get(ok).post(ok);
+
+  routesMulti = parseExpressApp(app2, { multipleMetadata: true });
+});
+
+describe('v5 parser output → HTML renderer', () => {
+  it('returns a non-empty string without throwing', () => {
+    const html = renderRoutesAsHtml(routes);
+    expect(typeof html).toBe('string');
+    expect(html.length).toBeGreaterThan(0);
+  });
+
+  it('contains all parsed paths as substrings', () => {
+    const html = renderRoutesAsHtml(routes);
+    const paths = routes.map((r) => (typeof r.path === 'string' ? r.path : ''));
+    for (const p of paths) {
+      expect(html).toContain(p);
+    }
+  });
+
+  it('handles type:"wildcard" without throwing or mangling output', () => {
+    const html = renderRoutesAsHtml(routes);
+    // /files/*splat must appear — type field must not break the renderer
+    expect(html).toContain('/files/*splat');
+  });
+
+  it('works with multipleMetadata:true output', () => {
+    const html = renderRoutesAsHtml(routesMulti);
+    expect(html.length).toBeGreaterThan(0);
+  });
+});
+
+describe('v5 parser output → Markdown renderer', () => {
+  it('returns a non-empty string without throwing', () => {
+    const md = renderRoutesAsMarkdown(routes);
+    expect(typeof md).toBe('string');
+    expect(md.length).toBeGreaterThan(0);
+  });
+
+  it('contains all parsed paths', () => {
+    const md = renderRoutesAsMarkdown(routes);
+    const paths = routes.map((r) => (typeof r.path === 'string' ? r.path : ''));
+    for (const p of paths) {
+      expect(md).toContain(p);
+    }
+  });
+
+  it('contains all HTTP methods in uppercase', () => {
+    const md = renderRoutesAsMarkdown(routes);
+    const methods = [...new Set(routes.map((r) => r.method.toUpperCase()))];
+    for (const m of methods) {
+      expect(md).toContain(m);
+    }
+  });
+
+  it('works with multipleMetadata:true output', () => {
+    const md = renderRoutesAsMarkdown(routesMulti);
+    expect(md.length).toBeGreaterThan(0);
+  });
+});
+
+describe('v5 parser output → JSON renderer', () => {
+  it('returns valid JSON without throwing', () => {
+    const json = renderRoutesAsJson(routes);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+
+  it('round-trips: parsed routes serialized then re-parsed equals the original', () => {
+    const json = renderRoutesAsJson(routes);
+    const parsed = JSON.parse(json) as RouteMetaData[];
+    // Compare key fields — JSON round-trip must preserve path, method, pathParams
+    expect(parsed).toHaveLength(routes.length);
+    for (let i = 0; i < routes.length; i++) {
+      expect(parsed[i].path).toEqual(routes[i].path);
+      expect(parsed[i].method).toEqual(routes[i].method);
+      expect(parsed[i].pathParams).toEqual(routes[i].pathParams);
+    }
+  });
+
+  it('preserves type:"wildcard" on the wildcard param through JSON', () => {
+    const json = renderRoutesAsJson(routes);
+    const parsed = JSON.parse(json) as RouteMetaData[];
+    const fileRoute = parsed.find((r) => typeof r.path === 'string' && r.path.includes('*splat'));
+    expect(fileRoute).toBeDefined();
+    expect(fileRoute!.pathParams[0].type).toBe('wildcard');
+  });
+
+  it('works with multipleMetadata:true output', () => {
+    const json = renderRoutesAsJson(routesMulti);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+});

--- a/src/__tests__/types.test-d.ts
+++ b/src/__tests__/types.test-d.ts
@@ -153,6 +153,25 @@ describe('issue #5 renderer type contract', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Express 5 type extensions
+// ---------------------------------------------------------------------------
+
+describe('Express 5 type extensions', () => {
+  it('Parameter.type accepts the documented union or undefined', () => {
+    type T = Parameter['type'];
+    expectTypeOf<T>().toEqualTypeOf<'param' | 'wildcard' | undefined>();
+  });
+
+  it('Existing Parameter shape with new field still satisfies toMatchObjectType', () => {
+    expectTypeOf<Parameter>().toMatchObjectType<{
+      in: string;
+      name: string;
+      required: boolean;
+    }>();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Gap (HIGH): withMetadata<M> compile-time rejection. Source: design Unit A2 AC,
 // "withMetadata<MySchema>({ ... }) rejects an input that doesn't match MySchema
 // at compile time." The positive case is covered by `types.test-d.ts:99`; the

--- a/src/express-parser/detect.ts
+++ b/src/express-parser/detect.ts
@@ -1,0 +1,52 @@
+/* eslint-disable no-underscore-dangle */
+import type { Express } from 'express';
+
+export type ExpressVersion = 4 | 5 | 'unknown';
+
+export interface DetectionResult {
+  version: ExpressVersion;
+  /**
+   * The router object to walk. For v4, this is `app._router` (or `undefined`
+   * for routeless apps). For v5, this is `app.router` (the function itself
+   * has a `.stack` property).
+   */
+  router: { stack: unknown[] } | undefined;
+}
+
+/**
+ * Detects whether the given app is Express 4, Express 5, or neither.
+ *
+ * Heuristic:
+ *
+ * - Express 4: `app._router` is truthy after first route registration.
+ * Express 4's `_router` is a function (Router extends Function) that also has a `.stack`.
+ * - Express 5: `app._router` is undefined; `app.router` is a function with a `.stack`.
+ *
+ * For an Express 4 app with no routes registered, `app._router` is undefined
+ * AND accessing `app.router` throws (the deprecated 3.x→4.x tripwire). The
+ * try/catch handles this — we report `version: 4, router: undefined`, and the
+ * dispatcher returns an empty array (matching the post-1.1.0 fix behavior).
+ */
+export const detectExpressVersion = (app: Express): DetectionResult => {
+  const a = app as unknown as { _router?: { stack: unknown[] }; router?: { stack: unknown[] } };
+
+  const router4 = a._router;
+  if (router4 && Array.isArray(router4.stack)) {
+    return { version: 4, router: router4 };
+  }
+
+  // Express 5: `app.router` is the canonical access; in Express 4 reading it
+  // throws (deprecation tripwire). Wrap in try/catch.
+  try {
+    const r = a.router;
+    if (r && Array.isArray(r.stack)) {
+      return { version: 5, router: r };
+    }
+  } catch {
+    // Express 4 with no routes registered: app._router is undefined AND
+    // app.router throws. Report v4 with no router.
+    return { version: 4, router: undefined };
+  }
+
+  return { version: 'unknown', router: undefined };
+};

--- a/src/express-parser/index.ts
+++ b/src/express-parser/index.ts
@@ -1,197 +1,38 @@
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-
-import { Express, Router } from 'express';
-import { RouteMetaData, RouteMetaDataMulti, ParseOptions, ExpressRegex, Key, Layer, Parameter, Route } from '../types';
+import type { Express } from 'express';
+import type { RouteMetaData, RouteMetaDataMulti, ParseOptions } from '../types';
+import { detectExpressVersion } from './detect';
+import { parseV4 } from './v4';
+import { parseV5 } from './v5';
 
 /**
- * Parses an Express app and generates a list of routes with metadata.
- *
- * @param app The Express app reference. Must be used after all routes have been attached.
- * @param options Optional parse options. Pass `{ multipleMetadata: true }` to allow multiple
- * metadata-bearing middlewares per route (returned as `metadata: any[]`).
- * By default the parser throws if it encounters more than one metadata middleware
- * on a route, matching v1.x behavior.
- * @returns List of routes with metadata, in declaration order.
+ * Parses an Express app and returns its routes with metadata. Auto-detects
+ * Express 4 vs Express 5; works with both. For Express 5, requires that
+ * `express-route-parser` was imported before any router was constructed
+ * (the auto-installed instrumentation captures mount paths at that time).
  */
 export function parseExpressApp(app: Express, options?: { multipleMetadata?: false }): RouteMetaData[];
 export function parseExpressApp(app: Express, options: { multipleMetadata: true }): RouteMetaDataMulti[];
 export function parseExpressApp(app: Express, options: ParseOptions = {}): RouteMetaData[] | RouteMetaDataMulti[] {
-  const parser = new ExpressPathParser(app, options);
-  return parser.appPaths;
+  const detection = detectExpressVersion(app);
+
+  if (detection.router === undefined) {
+    return [] as RouteMetaData[] & RouteMetaDataMulti[];
+  }
+
+  if (detection.version === 4) {
+    return parseV4(app, options);
+  }
+
+  if (detection.version === 5) {
+    // The detection result already gave us the v5 router; pass it directly so
+    // v5.ts doesn't re-do the lookup.
+    return parseV5(detection.router as Parameters<typeof parseV5>[0], options);
+  }
+
+  // 'unknown' — defensive: treat as no routes.
+  return [] as RouteMetaData[] & RouteMetaDataMulti[];
 }
 
-class ExpressPathParser {
-  private readonly _appPaths: (RouteMetaData | RouteMetaDataMulti)[];
-  private readonly _multipleMetadata: boolean;
-
-  public get appPaths(): RouteMetaData[] & RouteMetaDataMulti[] {
-    // The actual element shape matches whichever mode was selected; the
-    // overloads on parseExpressApp narrow it for callers.
-    return this._appPaths as RouteMetaData[] & RouteMetaDataMulti[];
-  }
-
-  constructor(app: Express, options: ParseOptions = {}) {
-    this._multipleMetadata = options.multipleMetadata === true;
-    this._appPaths = [];
-    // Express 4 lazy-initializes `_router` on first route registration. Before
-    // that, `_router` is undefined. Do NOT fall back to `app.router` — in
-    // Express 4 that's a deprecated accessor that throws on access (the 3.x→4.x
-    // migration left it as a tripwire). Just guard for undefined.
-    const router: Router | undefined = app._router;
-    if (router) {
-      router.stack.forEach((layer: Layer) => {
-        this.traverse('', layer, []);
-      });
-    }
-  }
-  /**
-   * Recursive traversal method for the express router and middleware tree.
-   *
-   * @param path The current path segment that we have traversed so far
-   * @param layer The current 'layer' of the router tree
-   * @param keys The keys for the parameter's in the current path branch of the traversal
-   * @returns void - base case saves result to internal object
-   */
-  private traverse = (path: string, layer: Layer, keys: Key[]): RouteMetaData | undefined => {
-    keys = [...keys, ...layer.keys];
-    if (layer.name === 'router' && layer.handle) {
-      layer.handle.stack.forEach((l: Layer) => {
-        path = path || '';
-        this.traverse(`${path}/${pathRegexParser(layer.regexp, layer.keys)}`, l, keys);
-      });
-    }
-    if (!layer.route || !layer.route.stack.length) {
-      return;
-    }
-    this._appPaths.push(...this.parseRouteLayer(layer, keys, path));
-  };
-  /**
-   * Parses a route object. Route objects are the leafs of an express router tree.
-   * Emits one RouteMetaData per distinct HTTP method registered on the route
-   * (e.g. `router.route('/x').post(...).get(...)` yields two entries).
-   *
-   * @param layer The layer of this route object - represents the stack of middleware and other meta data
-   * @param keys The full set of keys for this particular route
-   * @param basePath The base path as it was initial declared for this route
-   * @returns A list of ExpressPath objects holding the meta data for each method on the route
-   */
-  private parseRouteLayer = (layer: Layer, keys: Key[], basePath: string): (RouteMetaData | RouteMetaDataMulti)[] => {
-    const pathParams: Parameter[] = keys.map((key) => {
-      return { name: key.name, in: 'path', required: !key.optional };
-    });
-    const path = (basePath + layer.route.path).replace(/\/{2,}/gi, '/');
-
-    // Group route stack entries by HTTP method. Express creates one stack entry
-    // per `.method(handler)` invocation, so multi-handler calls like
-    // `app.get('/x', mw, h)` produce multiple entries that share a method, while
-    // chained calls like `.post(...).get(...)` produce entries with different
-    // methods. `.all()` produces entries with method=undefined, which we skip.
-    const methodGroups = new Map<string, Layer[]>();
-    for (const entry of layer.route.stack) {
-      if (!entry.method) continue;
-      const group = methodGroups.get(entry.method);
-      if (group) {
-        group.push(entry);
-      } else {
-        methodGroups.set(entry.method, [entry]);
-      }
-    }
-
-    const results: (RouteMetaData | RouteMetaDataMulti)[] = [];
-    for (const [method, entries] of methodGroups) {
-      const metaEntries = entries.filter((element) => (element?.handle as Route)?.metadata);
-
-      if (this._multipleMetadata) {
-        // Multi mode: always emit `metadata: any[]` (possibly empty).
-        const metadata = metaEntries.map((e) => (e.handle as Route).metadata);
-        results.push({ path, pathParams, method, metadata });
-      } else {
-        // Single mode: existing v1.x behavior, with a friendlier error message.
-        if (metaEntries.length > 1) {
-          throw new Error(
-            'Only one metadata middleware is allowed per route. ' +
-              'Pass { multipleMetadata: true } to parseExpressApp() to allow multiple.',
-          );
-        }
-        if (metaEntries.length === 0) {
-          results.push({ path, pathParams, method });
-        } else {
-          results.push({
-            path,
-            pathParams,
-            method,
-            metadata: (metaEntries[0].handle as Route).metadata,
-          });
-        }
-      }
-    }
-    return results;
-  };
-}
-
-/** Parses an express layer's regex and converts it to the original format seen in code.
- *
- * @param layerRegexPath The layer's regex pattern
- * @param keys The keys that represent the layer's path parameters
- * @returns The path string for that layer
- * Code inspired and modify from:
- * https://github.com/expressjs/express/issues/3308#issuecomment-300957572
- */
-const pathRegexParser = (layerRegexPath: ExpressRegex | string, keys: Key[]): string => {
-  if (typeof layerRegexPath === 'string') {
-    return layerRegexPath;
-  }
-  if (layerRegexPath.fast_slash) {
-    return '';
-  }
-  if (layerRegexPath.fast_star) {
-    return '*';
-  }
-  let mappedPath = '';
-  if (keys && keys.length) {
-    mappedPath = mapKeysToPath(layerRegexPath, keys);
-  }
-  const match = layerRegexPath
-    .toString()
-    .replace('\\/?', '')
-    .replace('(?=\\/|$)', '$')
-    .match(/^\/\^((?:\\[.*+?^${}()|[\]\\/]|[^.*+?^${}()|[\]\\/])*)\$\//) as string[];
-
-  if (match) {
-    return match[1].replace(/\\(.)/g, '$1').slice(1);
-  }
-  if (mappedPath) {
-    return mappedPath.slice(1);
-  }
-  return layerRegexPath.toString();
-};
-
-/**
- * Map's the keys/path variables to the regex inside a given path
- *
- * @param layerRegexPath The regex for a react router with path parameters
- * @param keys The keys that represent the path parameters
- * @returns The regex for a path variable converted to original string on the express route
- */
-const mapKeysToPath = (layerRegexPath: ExpressRegex, keys: Key[]): string => {
-  if (!keys || keys.length === 0) {
-    throw Error('must include atleast one key to map');
-  }
-  let convertedSubPath = layerRegexPath.toString();
-  for (const key of keys) {
-    if (key.optional) {
-      convertedSubPath = convertedSubPath.replace('(?:\\/([^\\/]+?))?\\', `/:${key.name}?`);
-    } else {
-      convertedSubPath = convertedSubPath.replace('(?:([^\\/]+?))', `:${key.name}`);
-    }
-  }
-  return convertedSubPath
-    .replace('/?(?=\\/|$)/i', '')
-    .replace('/^', '')
-    .replace(/\\/gi, '')
-    .replace(/\/{2,}/gi, '/');
-};
-
-export const onlyForTesting = { pathRegexParser, mapKeysToPath };
+// Re-export for the existing parser.test.ts which imports onlyForTesting
+// from '../express-parser'. This keeps the test file unchanged.
+export { onlyForTesting } from './v4';

--- a/src/express-parser/instrument.ts
+++ b/src/express-parser/instrument.ts
@@ -1,0 +1,114 @@
+/**
+ * Express 5 / `router@^2.x` discards the original mount-path string at Layer
+ * construction time. To recover it, we patch `Router.prototype.use` and
+ * `.route` to record the path argument on the resulting Layer(s) before
+ * returning to the user. The patch is idempotent and a no-op for consumers
+ * who don't have the `router` package installed (Express 4 only).
+ *
+ * Side-effected by `src/index.ts` import so consumers don't need a setup
+ * call. Patches `Router.prototype` once; subsequent imports are no-ops.
+ */
+
+const PATCHED_MARKER = Symbol.for('express-route-parser/patched');
+
+export interface CapturedPath {
+  /**
+   * The original path argument passed to `router.use(path, ...)` or
+   * `router.route(path)`. Stored on each newly-created Layer as a hidden
+   * symbol property so the v5 walker can reconstruct full paths.
+   */
+  path: string | RegExp | (string | RegExp)[];
+}
+
+/**
+ * Hidden property attached to v5 Layer instances by the patch. The v5 parser
+ * reads this to recover mount paths. The symbol form prevents collisions
+ * with any Layer field upstream might add.
+ */
+export const ORIGINAL_PATH = Symbol.for('express-route-parser/originalPath');
+
+/**
+ * Idempotent. Returns true if patching took effect (or was already in place);
+ * false if the `router` package isn't installed (Express 4 only deployment).
+ *
+ * Exported for tests and for the documented escape hatch
+ * `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1`.
+ */
+export const instrumentExpress5Router = (): boolean => {
+  let routerModule: unknown;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    routerModule = require('router');
+  } catch {
+    // No `router` package — Express 4-only consumer. Nothing to do.
+    return false;
+  }
+
+  const rm = routerModule as { prototype: RouterPrototype & { [PATCHED_MARKER]?: true } };
+  const proto = rm.prototype;
+
+  if (proto[PATCHED_MARKER]) {
+    return true; // already patched; idempotent
+  }
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const origUse = proto.use;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const origRoute = proto.route;
+
+  proto.use = function patchedUse(this: RouterStack, ...args: unknown[]): unknown {
+    const stackBefore = this.stack.length;
+    const ret = origUse.apply(this, args);
+    const mountPath = pathArg(args[0]);
+    if (mountPath !== undefined) {
+      for (let i = stackBefore; i < this.stack.length; i++) {
+        this.stack[i][ORIGINAL_PATH] = mountPath;
+      }
+    }
+    return ret;
+  };
+
+  proto.route = function patchedRoute(this: RouterStack, path: string): unknown {
+    const ret = origRoute.call(this, path);
+    const newLayer = this.stack[this.stack.length - 1] as RouterLayer | undefined;
+    if (newLayer) newLayer[ORIGINAL_PATH] = path;
+    return ret;
+  };
+
+  Object.defineProperty(proto, PATCHED_MARKER, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+
+  return true;
+};
+
+const pathArg = (first: unknown): string | RegExp | (string | RegExp)[] | undefined => {
+  if (typeof first === 'string') return first;
+  if (first instanceof RegExp) return first;
+  if (Array.isArray(first) && first.every((p) => typeof p === 'string' || p instanceof RegExp)) {
+    return first;
+  }
+  return undefined;
+};
+
+// Minimal duck-typed shapes for the parts of `router@2` we touch. Keeping
+// them local avoids a runtime dependency on the package's types.
+interface RouterPrototype {
+  use(...args: unknown[]): unknown;
+  route(path: string): unknown;
+}
+interface RouterStack {
+  stack: RouterLayer[];
+}
+interface RouterLayer {
+  [ORIGINAL_PATH]?: string | RegExp | (string | RegExp)[];
+}
+
+// Side-effect: install on import unless explicitly disabled. The env-var
+// escape hatch is for unusual setups (lazy-loaded modules, test isolation).
+if (process.env.EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT !== '1') {
+  instrumentExpress5Router();
+}

--- a/src/express-parser/v4.ts
+++ b/src/express-parser/v4.ts
@@ -1,0 +1,188 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
+import { Express, Router } from 'express';
+import { RouteMetaData, RouteMetaDataMulti, ParseOptions, ExpressRegex, Key, Layer, Parameter, Route } from '../types';
+
+/**
+ * Internal entry point for Express 4 parsing. Called by the dispatcher
+ * in `src/express-parser/index.ts`.
+ */
+export const parseV4 = (app: Express, options: ParseOptions): RouteMetaData[] | RouteMetaDataMulti[] => {
+  return new ExpressPathParser(app, options).appPaths;
+};
+
+class ExpressPathParser {
+  private readonly _appPaths: (RouteMetaData | RouteMetaDataMulti)[];
+  private readonly _multipleMetadata: boolean;
+
+  public get appPaths(): RouteMetaData[] & RouteMetaDataMulti[] {
+    // The actual element shape matches whichever mode was selected; the
+    // overloads on parseExpressApp narrow it for callers.
+    return this._appPaths as RouteMetaData[] & RouteMetaDataMulti[];
+  }
+
+  constructor(app: Express, options: ParseOptions = {}) {
+    this._multipleMetadata = options.multipleMetadata === true;
+    this._appPaths = [];
+    // Express 4 lazy-initializes `_router` on first route registration. Before
+    // that, `_router` is undefined. Do NOT fall back to `app.router` — in
+    // Express 4 that's a deprecated accessor that throws on access (the 3.x→4.x
+    // migration left it as a tripwire). Just guard for undefined.
+    const router: Router | undefined = app._router;
+    if (router) {
+      router.stack.forEach((layer: Layer) => {
+        this.traverse('', layer, []);
+      });
+    }
+  }
+  /**
+   * Recursive traversal method for the express router and middleware tree.
+   *
+   * @param path The current path segment that we have traversed so far
+   * @param layer The current 'layer' of the router tree
+   * @param keys The keys for the parameter's in the current path branch of the traversal
+   * @returns void - base case saves result to internal object
+   */
+  private traverse = (path: string, layer: Layer, keys: Key[]): RouteMetaData | undefined => {
+    keys = [...keys, ...layer.keys];
+    if (layer.name === 'router' && layer.handle) {
+      layer.handle.stack.forEach((l: Layer) => {
+        path = path || '';
+        this.traverse(`${path}/${pathRegexParser(layer.regexp, layer.keys)}`, l, keys);
+      });
+    }
+    if (!layer.route || !layer.route.stack.length) {
+      return;
+    }
+    this._appPaths.push(...this.parseRouteLayer(layer, keys, path));
+  };
+  /**
+   * Parses a route object. Route objects are the leafs of an express router tree.
+   * Emits one RouteMetaData per distinct HTTP method registered on the route
+   * (e.g. `router.route('/x').post(...).get(...)` yields two entries).
+   *
+   * @param layer The layer of this route object - represents the stack of middleware and other meta data
+   * @param keys The full set of keys for this particular route
+   * @param basePath The base path as it was initial declared for this route
+   * @returns A list of ExpressPath objects holding the meta data for each method on the route
+   */
+  private parseRouteLayer = (layer: Layer, keys: Key[], basePath: string): (RouteMetaData | RouteMetaDataMulti)[] => {
+    const pathParams: Parameter[] = keys.map((key) => {
+      return { name: key.name, in: 'path', required: !key.optional };
+    });
+    const path = (basePath + layer.route.path).replace(/\/{2,}/gi, '/');
+
+    // Group route stack entries by HTTP method. Express creates one stack entry
+    // per `.method(handler)` invocation, so multi-handler calls like
+    // `app.get('/x', mw, h)` produce multiple entries that share a method, while
+    // chained calls like `.post(...).get(...)` produce entries with different
+    // methods. `.all()` produces entries with method=undefined, which we skip.
+    const methodGroups = new Map<string, Layer[]>();
+    for (const entry of layer.route.stack) {
+      if (!entry.method) continue;
+      const group = methodGroups.get(entry.method);
+      if (group) {
+        group.push(entry);
+      } else {
+        methodGroups.set(entry.method, [entry]);
+      }
+    }
+
+    const results: (RouteMetaData | RouteMetaDataMulti)[] = [];
+    for (const [method, entries] of methodGroups) {
+      const metaEntries = entries.filter((element) => (element?.handle as Route)?.metadata);
+
+      if (this._multipleMetadata) {
+        // Multi mode: always emit `metadata: any[]` (possibly empty).
+        const metadata = metaEntries.map((e) => (e.handle as Route).metadata);
+        results.push({ path, pathParams, method, metadata });
+      } else {
+        // Single mode: existing v1.x behavior, with a friendlier error message.
+        if (metaEntries.length > 1) {
+          throw new Error(
+            'Only one metadata middleware is allowed per route. ' +
+              'Pass { multipleMetadata: true } to parseExpressApp() to allow multiple.',
+          );
+        }
+        if (metaEntries.length === 0) {
+          results.push({ path, pathParams, method });
+        } else {
+          results.push({
+            path,
+            pathParams,
+            method,
+            metadata: (metaEntries[0].handle as Route).metadata,
+          });
+        }
+      }
+    }
+    return results;
+  };
+}
+
+/** Parses an express layer's regex and converts it to the original format seen in code.
+ *
+ * @param layerRegexPath The layer's regex pattern
+ * @param keys The keys that represent the layer's path parameters
+ * @returns The path string for that layer
+ * Code inspired and modify from:
+ * https://github.com/expressjs/express/issues/3308#issuecomment-300957572
+ */
+const pathRegexParser = (layerRegexPath: ExpressRegex | string, keys: Key[]): string => {
+  if (typeof layerRegexPath === 'string') {
+    return layerRegexPath;
+  }
+  if (layerRegexPath.fast_slash) {
+    return '';
+  }
+  if (layerRegexPath.fast_star) {
+    return '*';
+  }
+  let mappedPath = '';
+  if (keys && keys.length) {
+    mappedPath = mapKeysToPath(layerRegexPath, keys);
+  }
+  const match = layerRegexPath
+    .toString()
+    .replace('\\/?', '')
+    .replace('(?=\\/|$)', '$')
+    .match(/^\/\^((?:\\[.*+?^${}()|[\]\\/]|[^.*+?^${}()|[\]\\/])*)\$\//) as string[];
+
+  if (match) {
+    return match[1].replace(/\\(.)/g, '$1').slice(1);
+  }
+  if (mappedPath) {
+    return mappedPath.slice(1);
+  }
+  return layerRegexPath.toString();
+};
+
+/**
+ * Map's the keys/path variables to the regex inside a given path
+ *
+ * @param layerRegexPath The regex for a react router with path parameters
+ * @param keys The keys that represent the path parameters
+ * @returns The regex for a path variable converted to original string on the express route
+ */
+const mapKeysToPath = (layerRegexPath: ExpressRegex, keys: Key[]): string => {
+  if (!keys || keys.length === 0) {
+    throw Error('must include atleast one key to map');
+  }
+  let convertedSubPath = layerRegexPath.toString();
+  for (const key of keys) {
+    if (key.optional) {
+      convertedSubPath = convertedSubPath.replace('(?:\\/([^\\/]+?))?\\', `/:${key.name}?`);
+    } else {
+      convertedSubPath = convertedSubPath.replace('(?:([^\\/]+?))', `:${key.name}`);
+    }
+  }
+  return convertedSubPath
+    .replace('/?(?=\\/|$)/i', '')
+    .replace('/^', '')
+    .replace(/\\/gi, '')
+    .replace(/\/{2,}/gi, '/');
+};
+
+export const onlyForTesting = { pathRegexParser, mapKeysToPath };

--- a/src/express-parser/v5.ts
+++ b/src/express-parser/v5.ts
@@ -1,0 +1,193 @@
+import type { RouteMetaData, RouteMetaDataMulti, Parameter, ParseOptions } from '../types';
+import { ORIGINAL_PATH } from './instrument';
+
+/**
+ * Parser for Express 5 / `router@^2.x` apps.
+ *
+ * Strategy: walk the router tree, joining captured mount paths
+ * (recorded by the `instrument` patch) with each `route.path`. Path-parameter
+ * extraction uses path-to-regexp v8's `pathToRegexp(path).keys`, which gives
+ * us `{ type: 'param' | 'wildcard', name: string }` directly — no regex
+ * source parsing.
+ */
+export const parseV5 = (
+  router: V5RouterStack,
+  options: ParseOptions,
+): RouteMetaData[] | RouteMetaDataMulti[] => {
+  const out: (RouteMetaData | RouteMetaDataMulti)[] = [];
+  walkStack(router.stack, '', out, options.multipleMetadata === true);
+  return out;
+};
+
+const walkStack = (
+  stack: V5Layer[],
+  parent: string,
+  out: (RouteMetaData | RouteMetaDataMulti)[],
+  multipleMetadata: boolean,
+): void => {
+  for (const layer of stack) {
+    if (layer.route) {
+      emitRoute(layer, parent, out, multipleMetadata);
+    } else if (layer.handle && Array.isArray((layer.handle as V5RouterStack).stack)) {
+      const mountPath = layer[ORIGINAL_PATH];
+      if (mountPath === undefined && layer.name === 'router') {
+        // The patch wasn't installed before this router was constructed.
+        // Surface a clear error so users can fix the import order.
+        throw new Error(
+          'express-route-parser: Express 5 sub-router was constructed before instrumentation. ' +
+            'Import `express-route-parser` (or call `instrumentExpress5Router()`) before creating any routers.',
+        );
+      }
+      const newParent =
+        mountPath !== undefined ? joinPath(parent, mountPathToString(mountPath)) : parent;
+      walkStack((layer.handle as V5RouterStack).stack, newParent, out, multipleMetadata);
+    }
+    // else: bare middleware — skipped
+  }
+};
+
+const emitRoute = (
+  layer: V5Layer,
+  parent: string,
+  out: (RouteMetaData | RouteMetaDataMulti)[],
+  multipleMetadata: boolean,
+): void => {
+  if (!layer.route) return; // narrow
+
+  const routePathRaw = layer.route.path;
+  const finalPath = joinPath(parent, routePathRaw);
+
+  const pathParams = extractParameters(routePathRaw);
+
+  // Group by HTTP method (issue #7 fix logic — same shape in v5)
+  const methodGroups = new Map<string, V5RouteEntry[]>();
+  for (const entry of layer.route.stack) {
+    if (!entry.method) continue;
+    const group = methodGroups.get(entry.method);
+    if (group) group.push(entry);
+    else methodGroups.set(entry.method, [entry]);
+  }
+
+  for (const [method, entries] of methodGroups) {
+    const metaEntries = entries.filter((e) => e?.handle?.metadata !== undefined);
+
+    if (multipleMetadata) {
+      const metadata = metaEntries.map((e) => e.handle?.metadata);
+      out.push({ path: finalPath, pathParams, method, metadata });
+    } else {
+      if (metaEntries.length > 1) {
+        throw new Error(
+          'Only one metadata middleware is allowed per route. ' +
+            'Pass { multipleMetadata: true } to parseExpressApp() to allow multiple.',
+        );
+      }
+      if (metaEntries.length === 0) {
+        out.push({ path: finalPath, pathParams, method });
+      } else {
+        out.push({
+          path: finalPath,
+          pathParams,
+          method,
+          metadata: metaEntries[0].handle?.metadata,
+        });
+      }
+    }
+  }
+};
+
+/**
+ * Extract path parameters from an Express 5 route path string using
+ * path-to-regexp v8. Returns an empty array for paths with no parameters
+ * or for non-string (regex / array) paths — those aren't parsed for params.
+ */
+const extractParameters = (path: string | RegExp | (string | RegExp)[]): Parameter[] => {
+  if (typeof path !== 'string') return [];
+
+  // Lazy-require so we don't load path-to-regexp on Express 4-only deployments.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+  const { pathToRegexp } = require('path-to-regexp');
+  const p2r = pathToRegexp as (
+    s: string,
+  ) => { regexp: RegExp; keys: { type: 'param' | 'wildcard'; name: string }[] };
+
+  let parsed: { keys: { type: 'param' | 'wildcard'; name: string }[] };
+  try {
+    parsed = p2r(path);
+  } catch {
+    // Path-to-regexp v8 throws on syntactically invalid paths. Fall back to
+    // empty params; the user's paths are their problem.
+    return [];
+  }
+
+  return parsed.keys.map((k) => ({
+    name: k.name,
+    in: 'path',
+    // path-to-regexp v8 doesn't model "optional" as a flag on the key; an
+    // optional segment in the path source produces a param with the same shape
+    // but the segment is wrapped in `{...}`. Detecting that requires a second
+    // pass on the raw source. For v1 of this design: report `required: true`
+    // for non-wildcard params unless we can detect optional (see implementation note).
+    required: k.type !== 'wildcard' && !isOptional(path, k.name),
+    type: k.type,
+  }));
+};
+
+/**
+ * Heuristic: detect if a named segment appears inside `{...}` in the path
+ * source. path-to-regexp v8 expresses optional segments via `{...}` wrappers
+ * around the segment; the segment's `key.name` is preserved.
+ *
+ * Examples:
+ *
+ * - `/users/:id` — id NOT optional
+ * - `/users/{:id}` — id optional
+ * - `/users{/:id}` — id optional with leading slash
+ * - `/files/*splat` — splat (separately classified as wildcard)
+ * - `/files/{*splat}` — wildcard, also optional in zero-match sense
+ */
+const isOptional = (rawPath: string, name: string): boolean => {
+  // Find a `{...}` group containing `:name` or `*name`.
+  const re = new RegExp('\\{[^}]*[:*]' + escapeRegex(name) + '[^a-zA-Z0-9_]', 'g');
+  const altRe = new RegExp('\\{[^}]*[:*]' + escapeRegex(name) + '\\}', 'g');
+  return re.test(rawPath) || altRe.test(rawPath);
+};
+
+const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const joinPath = (parent: string, child: string): string => {
+  if (!parent) return child || '/';
+  if (!child || child === '/') return parent;
+  return (parent + child).replace(/\/{2,}/g, '/');
+};
+
+const mountPathToString = (p: string | RegExp | (string | RegExp)[]): string => {
+  if (typeof p === 'string') return p;
+  if (p instanceof RegExp) return p.toString();
+  // Array form: match v4 parser's existing behavior — join with comma.
+  return p.map((x) => (typeof x === 'string' ? x : x.toString())).join(',');
+};
+
+// ---- Local duck-typed shapes for v5 / router@2 layers ----
+
+interface V5RouterStack {
+  stack: V5Layer[];
+}
+
+type V5HandleFn = (...args: any[]) => unknown;
+
+interface V5Layer {
+  name: string;
+  handle?: V5HandleFn | V5RouterStack;
+  route?: {
+    path: string;
+    stack: V5RouteEntry[];
+  };
+  [ORIGINAL_PATH]?: string | RegExp | (string | RegExp)[];
+}
+
+interface V5RouteEntry {
+  method?: string;
+  handle?: {
+    metadata?: unknown;
+  };
+}

--- a/src/express-parser/v5.ts
+++ b/src/express-parser/v5.ts
@@ -6,28 +6,30 @@ import { ORIGINAL_PATH } from './instrument';
  *
  * Strategy: walk the router tree, joining captured mount paths
  * (recorded by the `instrument` patch) with each `route.path`. Path-parameter
- * extraction uses path-to-regexp v8's `pathToRegexp(path).keys`, which gives
- * us `{ type: 'param' | 'wildcard', name: string }` directly — no regex
- * source parsing.
+ * extraction uses path-to-regexp v8's `parse()`, which exposes the structural
+ * AST (`Text | Parameter | Wildcard | Group`). We walk the AST per layer and
+ * accumulate parameters across nested mounts so the leaf route reports its
+ * full ancestor chain, matching v4 behavior.
  */
 export const parseV5 = (
   router: V5RouterStack,
   options: ParseOptions,
 ): RouteMetaData[] | RouteMetaDataMulti[] => {
   const out: (RouteMetaData | RouteMetaDataMulti)[] = [];
-  walkStack(router.stack, '', out, options.multipleMetadata === true);
+  walkStack(router.stack, '', [], out, options.multipleMetadata === true);
   return out;
 };
 
 const walkStack = (
   stack: V5Layer[],
   parent: string,
+  parentParams: Parameter[],
   out: (RouteMetaData | RouteMetaDataMulti)[],
   multipleMetadata: boolean,
 ): void => {
   for (const layer of stack) {
     if (layer.route) {
-      emitRoute(layer, parent, out, multipleMetadata);
+      emitRoute(layer, parent, parentParams, out, multipleMetadata);
     } else if (layer.handle && Array.isArray((layer.handle as V5RouterStack).stack)) {
       const mountPath = layer[ORIGINAL_PATH];
       if (mountPath === undefined && layer.name === 'router') {
@@ -40,7 +42,16 @@ const walkStack = (
       }
       const newParent =
         mountPath !== undefined ? joinPath(parent, mountPathToString(mountPath)) : parent;
-      walkStack((layer.handle as V5RouterStack).stack, newParent, out, multipleMetadata);
+      // Only string mount paths can carry path-to-regexp params. Regex and
+      // array mount forms have no named segments — skip them silently.
+      const segmentParams = typeof mountPath === 'string' ? extractParameters(mountPath) : [];
+      walkStack(
+        (layer.handle as V5RouterStack).stack,
+        newParent,
+        [...parentParams, ...segmentParams],
+        out,
+        multipleMetadata,
+      );
     }
     // else: bare middleware — skipped
   }
@@ -49,6 +60,7 @@ const walkStack = (
 const emitRoute = (
   layer: V5Layer,
   parent: string,
+  parentParams: Parameter[],
   out: (RouteMetaData | RouteMetaDataMulti)[],
   multipleMetadata: boolean,
 ): void => {
@@ -57,7 +69,7 @@ const emitRoute = (
   const routePathRaw = layer.route.path;
   const finalPath = joinPath(parent, routePathRaw);
 
-  const pathParams = extractParameters(routePathRaw);
+  const pathParams = [...parentParams, ...extractParameters(routePathRaw)];
 
   // Group by HTTP method (issue #7 fix logic — same shape in v5)
   const methodGroups = new Map<string, V5RouteEntry[]>();
@@ -97,62 +109,55 @@ const emitRoute = (
 
 /**
  * Extract path parameters from an Express 5 route path string using
- * path-to-regexp v8. Returns an empty array for paths with no parameters
- * or for non-string (regex / array) paths — those aren't parsed for params.
+ * path-to-regexp v8's structural `parse()`. Returns an empty array for paths
+ * with no parameters or for non-string (regex / array) paths — those aren't
+ * parsed for params.
+ *
+ * Optionality is structural: a `:name` or `*name` token is reported with
+ * `required: false` iff it appears inside a `{...}` group in the path AST.
+ * Wildcards are always reported `required: false` (they match zero or more
+ * segments by definition).
  */
 const extractParameters = (path: string | RegExp | (string | RegExp)[]): Parameter[] => {
   if (typeof path !== 'string') return [];
 
   // Lazy-require so we don't load path-to-regexp on Express 4-only deployments.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
-  const { pathToRegexp } = require('path-to-regexp');
-  const p2r = pathToRegexp as (
-    s: string,
-  ) => { regexp: RegExp; keys: { type: 'param' | 'wildcard'; name: string }[] };
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { parse } = require('path-to-regexp') as typeof import('path-to-regexp');
 
-  let parsed: { keys: { type: 'param' | 'wildcard'; name: string }[] };
+  let data: import('path-to-regexp').TokenData;
   try {
-    parsed = p2r(path);
+    data = parse(path);
   } catch {
-    // Path-to-regexp v8 throws on syntactically invalid paths. Fall back to
+    // path-to-regexp v8 throws on syntactically invalid paths. Fall back to
     // empty params; the user's paths are their problem.
     return [];
   }
 
-  return parsed.keys.map((k) => ({
-    name: k.name,
-    in: 'path',
-    // path-to-regexp v8 doesn't model "optional" as a flag on the key; an
-    // optional segment in the path source produces a param with the same shape
-    // but the segment is wrapped in `{...}`. Detecting that requires a second
-    // pass on the raw source. For v1 of this design: report `required: true`
-    // for non-wildcard params unless we can detect optional (see implementation note).
-    required: k.type !== 'wildcard' && !isOptional(path, k.name),
-    type: k.type,
-  }));
+  const out: Parameter[] = [];
+  walkTokens(data.tokens, false, out);
+  return out;
 };
 
-/**
- * Heuristic: detect if a named segment appears inside `{...}` in the path
- * source. path-to-regexp v8 expresses optional segments via `{...}` wrappers
- * around the segment; the segment's `key.name` is preserved.
- *
- * Examples:
- *
- * - `/users/:id` — id NOT optional
- * - `/users/{:id}` — id optional
- * - `/users{/:id}` — id optional with leading slash
- * - `/files/*splat` — splat (separately classified as wildcard)
- * - `/files/{*splat}` — wildcard, also optional in zero-match sense
- */
-const isOptional = (rawPath: string, name: string): boolean => {
-  // Find a `{...}` group containing `:name` or `*name`.
-  const re = new RegExp('\\{[^}]*[:*]' + escapeRegex(name) + '[^a-zA-Z0-9_]', 'g');
-  const altRe = new RegExp('\\{[^}]*[:*]' + escapeRegex(name) + '\\}', 'g');
-  return re.test(rawPath) || altRe.test(rawPath);
+const walkTokens = (
+  tokens: import('path-to-regexp').Token[],
+  inGroup: boolean,
+  out: Parameter[],
+): void => {
+  for (const t of tokens) {
+    if (t.type === 'param' || t.type === 'wildcard') {
+      out.push({
+        name: t.name,
+        in: 'path',
+        required: !inGroup && t.type !== 'wildcard',
+        type: t.type,
+      });
+    } else if (t.type === 'group') {
+      walkTokens(t.tokens, true, out);
+    }
+    // 'text' tokens carry no params
+  }
 };
-
-const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const joinPath = (parent: string, child: string): string => {
   if (!parent) return child || '/';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+// Side-effect import: auto-install the Router prototype patch for Express 5
+// before any user-imported router can be constructed. Loading this module
+// before `express` works in typical apps where imports are at module top.
+import './express-parser/instrument';
+
 export { parseExpressApp } from './express-parser';
 export { withMetadata } from './with-metadata';
 export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 import './express-parser/instrument';
 
 export { parseExpressApp } from './express-parser';
+export { instrumentExpress5Router } from './express-parser/instrument';
 export { withMetadata } from './with-metadata';
 export * from './types';
 export * from './renderers';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,16 @@ export interface Parameter {
   in: string;
   name: string;
   required: boolean;
+  /**
+   * The kind of path parameter, when known. Populated for routes parsed from
+   * Express 5 (which exposes path-to-regexp v8's typed `keys` array). Absent
+   * for Express 4 routes — the v4 regex-recovery path doesn't preserve this
+   * distinction.
+   *
+   * - `'param'` — a normal `:name` segment (one path component)
+   * - `'wildcard'` — a `*splat` segment (zero or more path components)
+   */
+  type?: 'param' | 'wildcard';
   [key: string]: any;
 }
 


### PR DESCRIPTION
Adds Express 5 support while keeping Express 4 working unchanged. Designed in `docs/design/express-5-support.md`; e2e test design in `docs/design/express-5-test-suite.md` (both included in this PR for review context).

**Ships as 2.0.0** — peer-dep widening from `^4.x` to `^4.x || ^5.x` is a breaking change under strict semver. That is the only intentional break.

## What's in here

### Core architecture (`46e6e41`)

`parseExpressApp(app)` now auto-detects Express 4 vs 5 at parse time and dispatches:

```
src/express-parser/
├── index.ts        ← thin dispatcher
├── detect.ts       ← Express version detection (try/catch around the 4.x throw)
├── instrument.ts   ← monkey-patch on Router.prototype.use/route, auto-runs on import
├── v4.ts           ← existing parser, moved verbatim
└── v5.ts           ← new walker; uses path-to-regexp v8 parse() AST
```

**The hard problem solved.** Express 5 discards mount-path strings at `Layer` construction; only opaque matcher closures survive. We patch `Router.prototype.use` and `.route` (the `router@^2.x` package's prototype, shared globally via Node module cache) to record the path argument before delegating. Stored on each Layer via a `Symbol.for('express-route-parser/originalPath')` hidden property. The patch is auto-installed when the package is imported (idempotent, no-op for v4-only consumers via try/catch around `require('router')`). Opt-out: `EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT=1` plus a manual `instrumentExpress5Router()` call.

### v5 surface

| Express 5 syntax | Output |
|---|---|
| `:param` | `{ type: 'param', required: true }` |
| `*splat` | `{ type: 'wildcard', required: false }` |
| `{:id}` / `{/:id}` | `{ type: 'param', required: false }` (structural detection) |

`Parameter.type?: 'param' \| 'wildcard'` is a new optional field — populated only for v5 routes, absent on v4. Non-breaking for existing consumers.

### Parity fixes (`e7b8337`, `b91e9b7`)

These close gaps the original v5 work deferred as \"out of scope\":

- **Ancestor pathParams accumulate through nested mounts** — `app.use('/api/:v', router); router.get('/users/:id', h)` now reports `:v` and `:id` (was reporting only `:id`, a regression vs v4 behavior).
- **Optional-segment detection is structural**, using path-to-regexp v8's public `parse()` AST. `Group` tokens (`{...}`) are the source of truth. Replaces the regex heuristic shipped in `46e6e41`.
- **`instrumentExpress5Router()` is publicly exported** from the package (was only reachable via deep import).
- **Sub-process tests cover the env-var escape hatch and the import-order failure mode.**

### Test investment

| | Initial | After parity fixes | After e2e suite |
|---|---:|---:|---:|
| Test files | 6 | 7 | **12** |
| Tests | 117 | 142 | **173** |

New v5 coverage:
- Renderer integration with real v5-parsed routes (was synthetic fixtures only)
- README v5 example pinned by `example-v5.test.ts`
- Cross-version (v4 + v5 in same process; asserts `Parameter.type` distinction)
- Live HTTP smoke — boots a real Express 5 server, fetches each parsed route, expects 2xx
- Sub-process tests — env-var skip, manual instrument, import-order working/broken
- All HTTP methods, big multi-method `.route()` chains, idempotent instrument
- Error middleware / 404 catchall / `router.param()` / bare-middleware skipping
- Same-prefix mounts, `.all()` interleaving

### Documentation

- `CHANGELOG.md` — `[Unreleased]` describes the full 2.0.0 surface (Added / Fixed / Changed / Added (dev))
- `README.md` — Express 5 section with import-order requirement, path-syntax migration, `Parameter.type`, manual `instrumentExpress5Router()` example
- `docs/design/express-5-support.md` — original design + Hardening Options split into \"Implemented in 2.0.0\" and \"Still Deferred\"
- `docs/design/express-5-test-suite.md` — e2e test suite design

## Adaptation from the original design

- `detect.ts` simplified vs. the design draft. Design assumed `app._router = false` on Express 5 (based on PoC research); actual Express 5.2.1 has `app._router = undefined`. Detection now uses a truthy-and-has-`.stack` check that handles all four states (v4 populated, v4 empty, v5 always, neither).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — 173/173 pass
- [x] Live HTTP smoke verifies parsed paths actually route on a real Express 5 server
- [x] Sub-process tests rebuild `lib/` in `beforeAll` so they always run against current source
- [ ] CI passes on Node 20/22/24
- [ ] Reviewer: confirm peer-dep widening doesn't surprise existing Express 4 users (it shouldn't — `^4.x || ^5.x` is a strict superset of `^4.x`)
- [ ] Reviewer: skim the `Parameter.type` asymmetry (present on v5, absent on v4) — confirm intentional and documented
- [ ] After merge: `./scripts/release.sh major` cuts **2.0.0** to npm with provenance