### PR TITLE
chore: release prep 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - YYYY-MM-DD
 
 ### Added
 - **Express 5 support.** `parseExpressApp(app)` auto-detects Express 4 vs Express 5 and dispatches to
@@ -100,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial published version covered by this changelog. See git history for prior changes.
 
-[Unreleased]: https://github.com/nklisch/express-route-parser/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/nklisch/express-route-parser/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/nklisch/express-route-parser/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/nklisch/express-route-parser/compare/v1.0.6...v1.1.0
 [1.0.6]: https://github.com/nklisch/express-route-parser/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/nklisch/express-route-parser/releases/tag/v1.0.5


### PR DESCRIPTION
Graduates the `[Unreleased]` CHANGELOG section to `[2.0.0]` with a `YYYY-MM-DD` placeholder date.

The release script (`./scripts/release.sh 2.0.0`) will fill in the actual date when run from `main` after this merges.

## Test plan
- [x] CI green on this PR
- [ ] After merge: run `./scripts/release.sh 2.0.0` from main