### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - YYYY-MM-DD
+## [2.0.0] - 2026-05-04
 
 ### Added
 - **Express 5 support.** `parseExpressApp(app)` auto-detects Express 4 vs Express 5 and dispatches to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-route-parser",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "express-route-parser",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-route-parser",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "An Express plugin that can list the path and route endpoints of an Express app.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/example-v5.test.ts
+++ b/src/__tests__/example-v5.test.ts
@@ -17,18 +17,10 @@ describe('README v5 example', () => {
     };
 
     // Top-level route with metadata (mirrors the v4 example shape)
-    app.get(
-      '/resources/users/:id',
-      withMetadata({ operationId: 'getUserById', notes: 'These are some notes' }),
-      ok,
-    );
+    app.get('/resources/users/:id', withMetadata({ operationId: 'getUserById', notes: 'These are some notes' }), ok);
 
     // Nested sub-router with metadata on the leaf route
-    subrouter.get(
-      '/:resourceId',
-      withMetadata({ operationId: 'getResourceByEntity', hidden: true, schema: {} }),
-      ok,
-    );
+    subrouter.get('/:resourceId', withMetadata({ operationId: 'getResourceByEntity', hidden: true, schema: {} }), ok);
     router.use('/:entity', subrouter);
     app.use('/dashboard', router);
 

--- a/src/__tests__/http-smoke-v5.test.ts
+++ b/src/__tests__/http-smoke-v5.test.ts
@@ -92,14 +92,8 @@ describe('G6: HTTP smoke — every parsed route responds 2xx on its substituted 
       if (method === 'HEAD' || method === 'OPTIONS') continue;
 
       const res = await fetch(url, { method });
-      expect(
-        res.status,
-        `Expected 2xx for ${method} ${urlPath} but got ${res.status}`,
-      ).toBeGreaterThanOrEqual(200);
-      expect(
-        res.status,
-        `Expected 2xx for ${method} ${urlPath} but got ${res.status}`,
-      ).toBeLessThan(300);
+      expect(res.status, `Expected 2xx for ${method} ${urlPath} but got ${res.status}`).toBeGreaterThanOrEqual(200);
+      expect(res.status, `Expected 2xx for ${method} ${urlPath} but got ${res.status}`).toBeLessThan(300);
     }
   });
 });

--- a/src/__tests__/import-order.test.ts
+++ b/src/__tests__/import-order.test.ts
@@ -31,20 +31,12 @@ describe('import order — v5 sub-router patch timing', () => {
   }, 60_000);
 
   it('G8: lib required before user-routes module — parse succeeds', () => {
-    const out = execFileSync(
-      process.execPath,
-      [path.join(FIXTURE_DIR, 'import-order-good.cjs')],
-      { encoding: 'utf8' },
-    );
+    const out = execFileSync(process.execPath, [path.join(FIXTURE_DIR, 'import-order-good.cjs')], { encoding: 'utf8' });
     expect(out.trim()).toBe('OK: /api/:tenant/x');
   });
 
   it('A1: user-routes module required before lib — parse throws actionable error', () => {
-    const out = execFileSync(
-      process.execPath,
-      [path.join(FIXTURE_DIR, 'import-order-bad.cjs')],
-      { encoding: 'utf8' },
-    );
+    const out = execFileSync(process.execPath, [path.join(FIXTURE_DIR, 'import-order-bad.cjs')], { encoding: 'utf8' });
     expect(out).toMatch(/^THREW: /);
     expect(out).toMatch(/sub-router was constructed before instrumentation/);
   });

--- a/src/__tests__/no-auto-instrument.test.ts
+++ b/src/__tests__/no-auto-instrument.test.ts
@@ -34,27 +34,19 @@ describe('EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT escape hatch', () => {
   }, 60_000);
 
   it('skips the auto-patch; v5 sub-router parse throws the expected error', () => {
-    const out = execFileSync(
-      process.execPath,
-      [path.join(FIXTURE_DIR, 'no-auto-instrument.cjs')],
-      {
-        env: { ...process.env, EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT: '1' },
-        encoding: 'utf8',
-      },
-    );
+    const out = execFileSync(process.execPath, [path.join(FIXTURE_DIR, 'no-auto-instrument.cjs')], {
+      env: { ...process.env, EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT: '1' },
+      encoding: 'utf8',
+    });
     expect(out).toMatch(/^THREW: /);
     expect(out).toMatch(/sub-router was constructed before instrumentation/);
   });
 
   it('manual instrumentExpress5Router() before router construction restores parsing', () => {
-    const out = execFileSync(
-      process.execPath,
-      [path.join(FIXTURE_DIR, 'manual-instrument.cjs')],
-      {
-        env: { ...process.env, EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT: '1' },
-        encoding: 'utf8',
-      },
-    );
+    const out = execFileSync(process.execPath, [path.join(FIXTURE_DIR, 'manual-instrument.cjs')], {
+      env: { ...process.env, EXPRESS_ROUTE_PARSER_NO_AUTO_INSTRUMENT: '1' },
+      encoding: 'utf8',
+    });
     expect(out.trim()).toBe('OK: /api/:tenant/x');
   });
 });

--- a/src/__tests__/parser-v5.test.ts
+++ b/src/__tests__/parser-v5.test.ts
@@ -23,18 +23,14 @@ describe('Express 5 parser', () => {
 
   it('parses a single top-level route', () => {
     app.get('/health', ok);
-    expect(parseExpressApp(app)).toEqual([
-      { path: '/health', method: 'get', pathParams: [] },
-    ]);
+    expect(parseExpressApp(app)).toEqual([{ path: '/health', method: 'get', pathParams: [] }]);
   });
 
   it('extracts a required path parameter with type info', () => {
     app.get('/users/:id', ok);
     const [route] = parseExpressApp(app);
     expect(route.path).toBe('/users/:id');
-    expect(route.pathParams).toEqual([
-      { name: 'id', in: 'path', required: true, type: 'param' },
-    ]);
+    expect(route.pathParams).toEqual([{ name: 'id', in: 'path', required: true, type: 'param' }]);
   });
 
   it('parses an optional segment using v5 syntax {:name}', () => {
@@ -48,9 +44,7 @@ describe('Express 5 parser', () => {
   it('parses a wildcard segment as type "wildcard"', () => {
     app.get('/files/*splat', ok);
     const [route] = parseExpressApp(app);
-    expect(route.pathParams).toEqual([
-      { name: 'splat', in: 'path', required: false, type: 'wildcard' },
-    ]);
+    expect(route.pathParams).toEqual([{ name: 'splat', in: 'path', required: false, type: 'wildcard' }]);
   });
 
   it('parses nested sub-routers, joins mount paths, accumulates ancestor params', () => {
@@ -80,9 +74,7 @@ describe('Express 5 parser', () => {
     app.use(/^\/api/, r);
     const [route] = parseExpressApp(app);
     expect(route.method).toBe('get');
-    expect(route.pathParams).toEqual([
-      { name: 'id', in: 'path', required: true, type: 'param' },
-    ]);
+    expect(route.pathParams).toEqual([{ name: 'id', in: 'path', required: true, type: 'param' }]);
   });
 
   it('array mount path: leaf params only, no throw', () => {
@@ -91,9 +83,7 @@ describe('Express 5 parser', () => {
     app.use(['/v1', '/v2'], r);
     const [route] = parseExpressApp(app);
     expect(route.method).toBe('get');
-    expect(route.pathParams).toEqual([
-      { name: 'id', in: 'path', required: true, type: 'param' },
-    ]);
+    expect(route.pathParams).toEqual([{ name: 'id', in: 'path', required: true, type: 'param' }]);
   });
 
   it('three-level nested mount: all ancestor params are reported', () => {
@@ -117,9 +107,7 @@ describe('Express 5 parser', () => {
     r.get('/x', ok);
     app.use('/api{/:v}', r);
     const [route] = parseExpressApp(app);
-    expect(route.pathParams).toEqual([
-      { name: 'v', in: 'path', required: false, type: 'param' },
-    ]);
+    expect(route.pathParams).toEqual([{ name: 'v', in: 'path', required: false, type: 'param' }]);
   });
 
   it('nested optional groups: inner param is structurally optional', () => {
@@ -134,9 +122,7 @@ describe('Express 5 parser', () => {
   it('wildcard inside a group is still reported as wildcard / not required', () => {
     app.get('/{*splat}', ok);
     const [route] = parseExpressApp(app);
-    expect(route.pathParams).toEqual([
-      { name: 'splat', in: 'path', required: false, type: 'wildcard' },
-    ]);
+    expect(route.pathParams).toEqual([{ name: 'splat', in: 'path', required: false, type: 'wildcard' }]);
   });
 
   it('parses Router#route().get().post() as separate entries (issue #7 parity)', () => {
@@ -207,9 +193,7 @@ describe('Express 5 parser', () => {
     const [route] = parseExpressApp(app);
     expect(route.method).toBe('put');
     expect(route.path).toBe('/items/:id');
-    expect(route.pathParams).toEqual([
-      { name: 'id', in: 'path', required: true, type: 'param' },
-    ]);
+    expect(route.pathParams).toEqual([{ name: 'id', in: 'path', required: true, type: 'param' }]);
   });
 
   it('PATCH round-trip', () => {
@@ -229,16 +213,7 @@ describe('Express 5 parser', () => {
   // --- G4: full chained .route() with all methods -------------------------
 
   it('.route().all().get().post().put().patch().delete().head().options() — all explicit methods emitted, .all() skipped', () => {
-    app
-      .route('/multi')
-      .all(ok)
-      .get(ok)
-      .post(ok)
-      .put(ok)
-      .patch(ok)
-      .delete(ok)
-      .head(ok)
-      .options(ok);
+    app.route('/multi').all(ok).get(ok).post(ok).put(ok).patch(ok).delete(ok).head(ok).options(ok);
 
     const parsed = parseExpressApp(app);
     const methods = parsed.map((r) => r.method);
@@ -267,9 +242,7 @@ describe('Express 5 parser', () => {
     expect(instrumentExpress5Router()).toBe(true);
 
     app.get('/health', ok);
-    expect(parseExpressApp(app)).toEqual([
-      { path: '/health', method: 'get', pathParams: [] },
-    ]);
+    expect(parseExpressApp(app)).toEqual([{ path: '/health', method: 'get', pathParams: [] }]);
   });
 
   // --- A2: 4-arg error middleware silently skipped ------------------------
@@ -286,9 +259,7 @@ describe('Express 5 parser', () => {
 
   it('bare 3-arg fallthrough handler (404 catchall) is silently skipped', () => {
     app.get('/x', ok);
-    app.use((_req: unknown, res: { status: (n: number) => { send: () => void } }) =>
-      res.status(404).send(),
-    );
+    app.use((_req: unknown, res: { status: (n: number) => { send: () => void } }) => res.status(404).send());
     const parsed = parseExpressApp(app);
     expect(parsed).toEqual([{ path: '/x', method: 'get', pathParams: [] }]);
   });

--- a/src/express-parser/v5.ts
+++ b/src/express-parser/v5.ts
@@ -11,10 +11,7 @@ import { ORIGINAL_PATH } from './instrument';
  * accumulate parameters across nested mounts so the leaf route reports its
  * full ancestor chain, matching v4 behavior.
  */
-export const parseV5 = (
-  router: V5RouterStack,
-  options: ParseOptions,
-): RouteMetaData[] | RouteMetaDataMulti[] => {
+export const parseV5 = (router: V5RouterStack, options: ParseOptions): RouteMetaData[] | RouteMetaDataMulti[] => {
   const out: (RouteMetaData | RouteMetaDataMulti)[] = [];
   walkStack(router.stack, '', [], out, options.multipleMetadata === true);
   return out;
@@ -40,8 +37,7 @@ const walkStack = (
             'Import `express-route-parser` (or call `instrumentExpress5Router()`) before creating any routers.',
         );
       }
-      const newParent =
-        mountPath !== undefined ? joinPath(parent, mountPathToString(mountPath)) : parent;
+      const newParent = mountPath !== undefined ? joinPath(parent, mountPathToString(mountPath)) : parent;
       // Only string mount paths can carry path-to-regexp params. Regex and
       // array mount forms have no named segments — skip them silently.
       const segmentParams = typeof mountPath === 'string' ? extractParameters(mountPath) : [];
@@ -139,11 +135,7 @@ const extractParameters = (path: string | RegExp | (string | RegExp)[]): Paramet
   return out;
 };
 
-const walkTokens = (
-  tokens: import('path-to-regexp').Token[],
-  inGroup: boolean,
-  out: Parameter[],
-): void => {
+const walkTokens = (tokens: import('path-to-regexp').Token[], inGroup: boolean, out: Parameter[]): void => {
   for (const t of tokens) {
     if (t.type === 'param' || t.type === 'wildcard') {
       out.push({


### PR DESCRIPTION
Release **2.0.0**.

## Changelog

See `CHANGELOG.md` for the full entry. Highlights:

- **Express 5 support**: auto-detect, auto-instrument, dedicated v5 parser
- **BREAKING**: `peerDependencies.express` widened to `^4.x || ^5.x`
- New export: `instrumentExpress5Router()`
- New `Parameter.type` field (`'param'` vs `'wildcard'`) for v5 routes
- Fix: nested-router `pathParams` now accumulate ancestor params on v5 (parity with v4)
- Internal restructure: `src/express-parser/{v4,v5,index}.ts`
- E2E test suite for v5 (117 → 173 tests)

Also includes a `style:` commit reflowing v5 source/tests through Prettier (line-length collapses; no behavior change).

## Test plan

- [x] CI passes on this PR
- [ ] After merge: tag points at the merge commit
- [ ] After release: `2.0.0` shows on npm with provenance badge