### PR TITLE
chore(release): isolate npm version from lifecycle hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
     "prepare": "npm run build",
-    "prepublishOnly": "npm test && npm run lint",
-    "preversion": "npm run lint",
-    "version": "npm run format && git add -A src",
-    "postversion": "git push --follow-tags"
+    "prepublishOnly": "npm test && npm run lint"
   },
   "repository": {
     "type": "git",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -164,8 +164,11 @@ fi
 
 # Bump package.json and package-lock.json. The lockfile has the version in two
 # places (top-level "version" and packages."".version) — npm version covers both.
+# --ignore-scripts: the release flow owns commit/tag/push; any preversion /
+# version / postversion hook would interfere (e.g. a stray `git push` on a
+# branch with no upstream aborts the release mid-flight).
 info "bumping package.json + package-lock.json to $NEW_VERSION"
-npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version >/dev/null
+npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version --ignore-scripts >/dev/null
 
 # Sanity: verify the bump landed in both files.
 PKG_VER=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

The release script's `npm version --no-git-tag-version` still runs `preversion` / `version` / `postversion` hooks. The legacy `postversion` hook in `package.json` (`git push --follow-tags`) executed on a freshly created `release/X.Y.Z` branch with no upstream and aborted the bump step mid-flight — hit during the 2.0.0 release, where CHANGELOG and package.json were modified but never committed by the script.

## Fixes

- **`scripts/release.sh`** — pass `--ignore-scripts` to `npm version`. The release flow owns commit / tag / push; no user hook can interfere.
- **`package.json`** — drop the obsolete `preversion` / `version` / `postversion` hooks. The release script now drives lint, format, and push; these hooks were leftover from the pre-script "manual `npm version`" workflow.

## Test plan

- [x] Both edits are surgical and only affect the release path
- [ ] Validate on the next release (3.0.0 / 2.0.1)